### PR TITLE
Adding a dot to the pattern matching on the @ name as its a valid name.

### DIFF
--- a/pytubefix/extract.py
+++ b/pytubefix/extract.py
@@ -173,7 +173,7 @@ def channel_name(url: str) -> str:
         r"(?:\/(channel)\/([%\w\d_\-]+)(\/.*)?)",
         r"(?:\/(u)\/([%\d\w_\-]+)(\/.*)?)",
         r"(?:\/(user)\/([%\w\d_\-]+)(\/.*)?)",
-        r"(?:(@[%\w\d_-]+)(.*)?)"
+        r"(?:(@[%\w\d_-\.]+)(.*)?)"
     ]
     for pattern in patterns:
         regex = re.compile(pattern)


### PR DESCRIPTION
Some youtube names have dots in them, such as [OneMedia.](https://www.youtube.com/@OneMedia.) Which is different then OneMeda (no dot)

Adding that to the valid pattern