### PR TITLE
caption tests fixed

### DIFF
--- a/pytubefix/cli.py
+++ b/pytubefix/cli.py
@@ -234,7 +234,7 @@ def display_progress_bar(
 
     filled = int(round(max_width * bytes_received / float(filesize)))
     remaining = max_width - filled
-    progress_bar = ch * filled + " " * remaining
+    progress_bar = ch * max(filled, 1) + " " * remaining
     percent = round(100.0 * bytes_received / float(filesize), 1)
     text = f" ↳ |{progress_bar}| {percent}%\r"
     sys.stdout.write(text)

--- a/tests/test_captions.py
+++ b/tests/test_captions.py
@@ -149,37 +149,65 @@ def test_xml_captions(request_get):
 
 @mock.patch("pytubefix.captions.request")
 def test_generate_srt_captions(request):
-    request.get.return_value = '''
-    <?xml version="1.0" encoding="utf-8"?>
-    <transcript>
-        <text start="6.5" dur="1.7">[Herb, Software Engineer]
-            本影片包含隱藏式字幕。
-        </text>
-        <text start="8.3" dur="2.7">
-            如要啓動字幕，請按一下這裡的圖示。
-        </text>
-    </transcript>
+
+    clean_text = lambda x: x.replace(' ', '').replace('\n', '')
+
+    xml_data = '''
+    <?xml version="1.0" encoding="utf-8" ?>
+        <timedtext format="3">
+    <body>
+    <p t="10200" d="940">K-pop!</p>
+    <p t="13400" d="2800">That is so awkward to watch.</p>
+    <p t="16200" d="2080">YouTube Rewind 2018.</p>
+    <p t="18480" d="3520">The most disliked video
+    in the history of YouTube.</p>
+    <p t="22780" d="2220">In 2018, we made something
+    you didn’t like.</p>
+    <p t="25100" d="2470">So in 2019, let’s see what
+    you DID like.</p>
+    <p t="27580" d="1400">Because you’re better at this
+    than we are.</p>
+    <p t="45110" d="1310">This is my outfit!</p>
+    </body>
+</timedtext>
     '''
+
+    request.get.return_value = xml_data
 
     caption = Caption(
         {"url": "url1", "name": {"simpleText": "name1"}, "languageCode": "en", "vssId": ".en"}
     )
 
-    assert (
-            caption.generate_srt_captions()
-            .replace(' ', '')
-            .replace('\n', '')
-
-            == '''
+    expected_output = '''
         1
-        00:00:06,500 --> 00:00:08,200
-        [Herb, Software Engineer] 本影片包含隱藏式字幕。
-        
-        2
-        00:00:08,300 --> 00:00:11,000
-        如要啓動字幕，請按一下這裡的圖示。
+00:00:10,200 --> 00:00:11,140
+K-pop!
+2
+00:00:13,400 --> 00:00:16,200
+That is so awkward to watch.
+3
+00:00:16,200 --> 00:00:18,280
+YouTube Rewind 2018.
+4
+00:00:18,480 --> 00:00:22,000
+The most disliked video
+    in the history of YouTube.
+5
+00:00:22,780 --> 00:00:25,000
+In 2018, we made something
+    you didn’t like.
+6
+00:00:25,100 --> 00:00:27,570
+So in 2019, let’s see what
+    you DID like.
+7
+00:00:27,580 --> 00:00:28,980
+Because you’re better at this
+    than we are.
+8
+00:00:45,110 --> 00:00:46,420
+This is my outfit!
 '''
-            .replace(' ', '')
-            .replace('\n', '')
 
-            )
+    assert clean_text(caption.generate_srt_captions()) == clean_text(expected_output)
+

--- a/tests/test_captions.py
+++ b/tests/test_captions.py
@@ -52,7 +52,7 @@ def test_caption_query_get_by_language_code_when_not_exists():
         # assert not_found is not None  # should never reach here
 
 
-@mock.patch("pytube.captions.Caption.generate_srt_captions")
+@mock.patch("pytubefix.captions.Caption.generate_srt_captions")
 def test_download(srt):
     open_mock = mock_open()
     with patch("builtins.open", open_mock):
@@ -71,7 +71,7 @@ def test_download(srt):
         )
 
 
-@mock.patch("pytube.captions.Caption.generate_srt_captions")
+@mock.patch("pytubefix.captions.Caption.generate_srt_captions")
 def test_download_with_prefix(srt):
     open_mock = mock_open()
     with patch("builtins.open", open_mock):
@@ -91,7 +91,7 @@ def test_download_with_prefix(srt):
         )
 
 
-@mock.patch("pytube.captions.Caption.generate_srt_captions")
+@mock.patch("pytubefix.captions.Caption.generate_srt_captions")
 def test_download_with_output_path(srt):
     open_mock = mock_open()
     captions.target_directory = MagicMock(return_value="/target")
@@ -110,7 +110,7 @@ def test_download_with_output_path(srt):
         captions.target_directory.assert_called_with("blah")
 
 
-@mock.patch("pytube.captions.Caption.xml_captions")
+@mock.patch("pytubefix.captions.Caption.xml_captions")
 def test_download_xml_and_trim_extension(xml):
     open_mock = mock_open()
     with patch("builtins.open", open_mock):
@@ -139,7 +139,7 @@ def test_repr():
     assert repr(caption_query) == '{\'en\': <Caption lang="name1" code="en">}'
 
 
-@mock.patch("pytube.request.get")
+@mock.patch("pytubefix.request.get")
 def test_xml_captions(request_get):
     request_get.return_value = "test"
     caption = Caption(
@@ -148,7 +148,7 @@ def test_xml_captions(request_get):
     assert caption.xml_captions == "test"
 
 
-@mock.patch("pytube.captions.request")
+@mock.patch("pytubefix.captions.request")
 def test_generate_srt_captions(request):
 
     clean_text = lambda x: x.replace(' ', '').replace('\n', '')
@@ -171,7 +171,7 @@ def test_generate_srt_captions(request):
     <p t="45110" d="1310">This is my outfit!</p>
     </body>
 </timedtext>
-    '''
+    '''.strip()
 
     request.get.return_value = xml_data
 


### PR DESCRIPTION
Hi, Thanks for point out previous issue. unfortunately the code base is pretty old and tests are not well maintained the problem was the old test assert XML test string was actually old one which Youtube return as XML i guess so that's why my algorithm wasnt working properly because algorithm expected xml structure was different the real one i fixed and made clean please test yourself. i simple run all the cases which you provided in the MD file and works great.i will work on test in this project because tests is important this kinda dynamic projects i think youtube can change properties fast and we should keep up changes with tests :))