### PR TITLE
Added getting channel playlists

### DIFF
--- a/pytubefix/contrib/playlist.py
+++ b/pytubefix/contrib/playlist.py
@@ -316,7 +316,7 @@ class Playlist(Sequence):
         return len(self.video_urls)
 
     def __repr__(self) -> str:
-        return f"{repr(self.video_urls)}"
+        return f'<pytube.contrib.Playlist object: playlistId={self.playlist_id}>'
 
     @property
     @cache


### PR DESCRIPTION
This PR adds a new method that is able to obtain channel playlists.

The `playlists` method returns an iterable of Playlist objects.

It was necessary to change the `__repr__`  of the Playlist class so that instead of returning videos, it returns playlist objects.