### PR TITLE
Fixed AttributeError when trying to get shorts and live

### DIFF
--- a/pytubefix/contrib/channel.py
+++ b/pytubefix/contrib/channel.py
@@ -27,7 +27,8 @@ class Channel(Playlist):
         )
 
         self.videos_url = self.channel_url + '/videos'
-
+        self.shorts_url = self.channel_url + '/shorts'
+        self.live_url = self.channel_url + '/streams'
         self.playlists_url = self.channel_url + '/playlists'
         self.community_url = self.channel_url + '/community'
         self.featured_channels_url = self.channel_url + '/channels'


### PR DESCRIPTION
When trying to get shorts or live streams from any channel, an **AttributeError** is thrown.

The error occurs due to the non-assignment of the variables `self.shorts_url` and `self.live_url`, which were accidentally removed in this [PR](https://github.com/JuanBindez/pytubefix/pull/28/files#diff-f6a156e67d1ecaabbc982a3004d41eeb9bf94f75d25095a3bb336eda8be3b0ee).