### PR TITLE
Fix: Correct exception handling

### DIFF
--- a/pytubefix/__main__.py
+++ b/pytubefix/__main__.py
@@ -372,7 +372,7 @@ class YouTube:
             # Check_availability will raise the correct exception in most cases
             #  if it doesn't, ask for a report.
             self.check_availability()
-            raise exceptions.PytubeError(
+            raise exceptions.PytubeFixError(
                 (
                     f'Exception while accessing title of {self.watch_url}. '
                     'Please file a bug report at https://github.com/pytube/pytube'


### PR DESCRIPTION
Stack Trace for the error:
```
KeyError: 'videoDetails'
  File "pytubefix/__main__.py", line 370, in title
    self._title = self.vid_info['videoDetails']['title'] #+ self._author
AttributeError: module 'pytubefix.exceptions' has no attribute 'PytubeError'
  File "handlers/event_handlers.py", line 24, in wrapper
    response = func(*args, **kwargs)
  File "handlers/event_handlers.py", line 59, in wrapper
    return func(*args, **kwargs)
  File "handlers/artifact_processor/extractor.py", line 24, in extract
    data = extractor.run(**request.params)
  File "extractors/base.py", line 92, in run
    meta=self.get_meta_info(),
  File "extractors/youtube.py", line 43, in get_meta_info
    return yt_helpers.get_youtube_video_data(self.yt_obj)
  File "helpers/youtube.py", line 55, in get_youtube_video_data
    title=obj.title,
  File "pytubefix/__main__.py", line 375, in title
    raise exceptions.PytubeError(
```