### PR TITLE
Fixed urllib.error.HTTPError: HTTP Error 400: Bad Request 

### DIFF
--- a/pytubefix/innertube.py
+++ b/pytubefix/innertube.py
@@ -48,7 +48,7 @@ _default_clients = {
             'context': {
                 'client': {
                     'clientName': 'ANDROID',
-                    'clientVersion': '17.31.35',
+                    'clientVersion': '19.08.35',
                     'androidSdkVersion': 30
                 }
             },
@@ -64,7 +64,7 @@ _default_clients = {
             'context': {
                 'client': {
                     'clientName': 'IOS',
-                    'clientVersion': '17.33.2',
+                    'clientVersion': '19.08.35',
                     'deviceModel': 'iPhone14,3'
                 }
             }
@@ -95,7 +95,7 @@ _default_clients = {
             'context': {
                 'client': {
                     'clientName': 'ANDROID_EMBEDDED_PLAYER',
-                    'clientVersion': '17.31.35',
+                    'clientVersion': '19.08.35',
                     'clientScreen': 'EMBED',
                     'androidSdkVersion': 30,
                 }
@@ -111,7 +111,7 @@ _default_clients = {
             'context': {
                 'client': {
                     'clientName': 'IOS_MESSAGES_EXTENSION',
-                    'clientVersion': '17.33.2',
+                    'clientVersion': '19.08.35',
                     'deviceModel': 'iPhone14,3'
                 }
             }
@@ -141,7 +141,7 @@ _default_clients = {
             'context': {
                 'client': {
                     'clientName': 'ANDROID_MUSIC',
-                    'clientVersion': '5.16.51',
+                    'clientVersion': '6.40.52',
                     'androidSdkVersion': 30
                 }
             }
@@ -156,7 +156,7 @@ _default_clients = {
             'context': {
                 'client': {
                     'clientName': 'IOS_MUSIC',
-                    'clientVersion': '5.21',
+                    'clientVersion': '6.41',
                     'deviceModel': 'iPhone14,3'
                 }
             }


### PR DESCRIPTION
Recently YouTube started returning a 400 error randomly #35 .

As noted in the past, YouTube is refusing requests from ANDROID clients with older versions.

Client versions have been updated:

- ANDROID
- ANDROID_EMBED
- ANDROID_MUSIC
- IOS
- IOS_EMBED
- IOS_MUSIC