### PR TITLE
Chapters: fix last chapter duration bug

### DIFF
--- a/pytubefix/__main__.py
+++ b/pytubefix/__main__.py
@@ -332,7 +332,7 @@ class YouTube:
             )
 
             if i == len(chapters_data) - 1:
-                chapter_end = self.length - chapter_start
+                chapter_end = self.length
             else:
                 chapter_end = int(
                     chapters_data[i + 1]['chapterRenderer']['timeRangeStartMillis'] / 1000


### PR DESCRIPTION
Sorry, I missed that in my first PR...

It turned out, that the last chapter has a negative duration :cry: 
![image](https://github.com/JuanBindez/pytubefix/assets/5086053/8488be2b-8778-4a91-8602-8498215e3638)

So fixing a small code error in this PR
