### PR TITLE
Fixed Video Not Available

### DIFF
--- a/pytubefix/innertube.py
+++ b/pytubefix/innertube.py
@@ -52,7 +52,7 @@ _default_clients = {
                     'androidSdkVersion': 30
                 }
             },
-            "params": "CgIQBg"
+            "params": "CgIIAdgDAQ%3D%3D"
         },
         'header': {
             'User-Agent': 'com.google.android.youtube/',
@@ -249,7 +249,7 @@ _token_file = os.path.join(_cache_dir, 'tokens.json')
 
 class InnerTube:
     """Object for interacting with the innertube API."""
-    def __init__(self, client='ANDROID_MUSIC', use_oauth=False, allow_cache=True):
+    def __init__(self, client='ANDROID', use_oauth=False, allow_cache=True):
         """Initialize an InnerTube object.
 
         :param str client:


### PR DESCRIPTION
## Fixed video unavailable error for ANDROID clients #48 #50 .

The `ANDROID` client requires an argument to be sent along with the API request, without this parameter YouTube returns streams that last around 30 seconds or sends a muted video saying "_The following content is not available on this app. Watch this content on the latest version of YouTube_".

This PR updates this parameter, allowing the use of the `ANDROID` client.

This also fixes false age restriction #49. 