### PR TITLE
Compatibility fix with old versions of Python

### DIFF
--- a/merge.rocketfile
+++ b/merge.rocketfile
@@ -2,4 +2,10 @@ git add .
 git commit -m "merge.rocketfile"
 git checkout main
 git merge rc
-rocket build.rocketfile
+git add .
+git commit -m ' Implemented native js interpreter #63'
+git push -u origin main
+git tag v5.0.0
+git push --tag
+make clean
+make upload

--- a/pytubefix/chapters.py
+++ b/pytubefix/chapters.py
@@ -1,13 +1,18 @@
+# Native python imports
 from datetime import timedelta
-from dataclasses import dataclass
+from typing import List
 
 
-@dataclass
 class ChapterThumbnail:
     """Container for chapter thumbnails."""
-    width: int
-    height: int
-    url: str
+
+    def __init__(self, width: int, height: int, url: str):
+        self.width = width
+        self.height = height
+        self.url = url
+
+    def __repr__(self):
+        return f'<pytubefix.chapters.ChapterThumbnail: width={self.width}, height={self.height}, url={self.url}>'
 
 
 class Chapter:
@@ -15,7 +20,7 @@ class Chapter:
     title: str
     start_seconds: int
     duration: int  # in seconds
-    thumbnails: list[ChapterThumbnail]
+    thumbnails: List[ChapterThumbnail]
 
     def __init__(self, chapter_data: dict, duration: int):
         data = chapter_data['chapterRenderer']

--- a/pytubefix/contrib/search.py
+++ b/pytubefix/contrib/search.py
@@ -1,6 +1,7 @@
 """Module for interacting with YouTube search."""
 # Native python imports
 import logging
+from typing import List
 
 # Local imports
 from pytubefix import YouTube, Channel, Playlist
@@ -46,7 +47,7 @@ class Search:
         return self._completion_suggestions
 
     @property
-    def videos(self) -> list[YouTube]:
+    def videos(self) -> List[YouTube]:
         """Returns the search result videos.
 
         On first call, will generate and return the first set of results.
@@ -67,7 +68,7 @@ class Search:
         return [items for items in self._results['videos']]
 
     @property
-    def shorts(self) -> list[YouTube]:
+    def shorts(self) -> List[YouTube]:
         """Returns the search result shorts.
 
         On first call, will generate and return the first set of results.
@@ -88,7 +89,7 @@ class Search:
         return [items for items in self._results['shorts']]
 
     @property
-    def playlist(self) -> list[Playlist]:
+    def playlist(self) -> List[Playlist]:
         """Returns the search result playlist.
 
         On first call, will generate and return the first set of results.
@@ -109,7 +110,7 @@ class Search:
         return [items for items in self._results['playlist']]
 
     @property
-    def channel(self) -> list[Channel]:
+    def channel(self) -> List[Channel]:
         """Returns the search result channel.
 
         On first call, will generate and return the first set of results.

--- a/pytubefix/extract.py
+++ b/pytubefix/extract.py
@@ -89,7 +89,7 @@ def is_age_restricted(watch_html: str) -> bool:
     return True
 
 
-def playability_status(watch_html: str) -> tuple[str, str]:
+def playability_status(watch_html: str) -> Tuple[Any, Any]:
     """Return the playability status and status explanation of a video.
 
     For example, a video may have a status of LOGIN_REQUIRED, and an explanation


### PR DESCRIPTION
## Some recent changes in pytubefix caused error in old versions of python #56 #62 

The main cause of the errors was the type annotation that needs to be imported into the class in Python versions prior to 3.9.

There was also the import of the `dataclasses` class in **chapters.py** which was only implemented in the python 3.7+ version.