### PR TITLE
Added new client to overcome ANDROID instability

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,6 @@
 
     pip install pytubefix
 
-### In Ubuntu
-
-    pip install pytubefix --break-system-packages
 
 ## Quickstart:
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@
 
 ## A pytube fork with additional features and fixes.
 
-[Documentation](https://pytubefix.readthedocs.io)
-
 ----------
 ## install:
 

--- a/build.rocketfile
+++ b/build.rocketfile
@@ -1,7 +1,7 @@
 git add .
-git commit -m 'dev 5.1.2-rc1'
-git push -u origin dev
-git tag v5.1.2-rc1
+git commit -m 'fixed ANDROID / WEB client response #66'
+git push -u origin main
+git tag v5.1.2
 git push --tag
 make clean
 make upload

--- a/merge.rocketfile
+++ b/merge.rocketfile
@@ -1,11 +1,4 @@
 git add .
-git commit -m "merge.rocketfile"
+git commit -m "merge in command -> rocket merge.rocketfile"
 git checkout main
-git merge rc
-git add .
-git commit -m ' Implemented native js interpreter #63'
-git push -u origin main
-git tag v5.0.0
-git push --tag
-make clean
-make upload
+git merge dev

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pytubefix"
-version = "5.1.2-rc1"
+version = "5.1.2"
 authors = [
   { name="Juan Bindez", email="juanbindez780@gmail.com" },
 ]

--- a/pytubefix/__main__.py
+++ b/pytubefix/__main__.py
@@ -51,7 +51,7 @@ class YouTube:
     def __init__(
             self,
             url: str,
-            client: str = 'WEB',
+            client: str = 'ANDROID_TESTSUITE',
             on_progress_callback: Optional[Callable[[Any, bytes, int], None]] = None,
             on_complete_callback: Optional[Callable[[Any, Optional[str]], None]] = None,
             proxies: Dict[str, str] = None,

--- a/pytubefix/innertube.py
+++ b/pytubefix/innertube.py
@@ -223,7 +223,22 @@ _default_clients = {
         'api_key': 'AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8',
         'require_js_player': False
     },
-
+    'ANDROID_TESTSUITE': {
+        'innertube_context': {
+            'context': {
+                'client': {
+                    'clientName': 'ANDROID_TESTSUITE',
+                    'clientVersion': '1.9',
+                    'androidSdkVersion': 30
+                }
+            }
+        },
+        'header': {
+            'User-Agent': 'com.google.android.youtube/',
+        },
+        'api_key': 'AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8',
+        'require_js_player': False
+    },
     'MWEB': {
         'inertube_context': {
             'context': {

--- a/pytubefix/version.py
+++ b/pytubefix/version.py
@@ -1,4 +1,4 @@
-__version__ = "5.1.2-rc1"
+__version__ = "5.1.2"
 
 if __name__ == "__main__":
     print(__version__)


### PR DESCRIPTION
## This new client temporarily fixes the video unavailable problem on the ANDROID client #66 #68 

This is an Android test client that has a similar structure to ANDROID without the need for the protobuf parameter.

The WEB client is a great option due to its stability, but it can cause slowdowns due to the decryption steps #67.

For now this new client could be used while ANDROID is unstable.