### PR TITLE
Fixed problem getting subtitles

### DIFF
--- a/pytubefix/__main__.py
+++ b/pytubefix/__main__.py
@@ -363,8 +363,11 @@ class YouTube:
 
         :rtype: List[Caption]
         """
+
+        innertube_response = InnerTube(client='WEB').player(self.video_id)
+
         raw_tracks = (
-            self.vid_info.get("captions", {})
+            innertube_response.get("captions", {})
             .get("playerCaptionsTracklistRenderer", {})
             .get("captionTracks", [])
         )

--- a/pytubefix/captions.py
+++ b/pytubefix/captions.py
@@ -46,7 +46,10 @@ class Caption:
     @property
     def json_captions(self) -> dict:
         """Download and parse the json caption tracks."""
-        json_captions_url = self.url.replace('fmt=srv3', 'fmt=json3')
+        if 'ftm=' in self.url:
+            json_captions_url = self.url.replace('fmt=srv3', 'fmt=json3')
+        else:
+            json_captions_url = self.url + '&fmt=json3'
         text = request.get(json_captions_url)
         parsed = json.loads(text)
         assert parsed['wireMagic'] == 'pb3', 'Unexpected captions format'
@@ -98,8 +101,8 @@ class Caption:
         root = ElementTree.fromstring(xml_captions)
 
         i = 0
-        for child in list(root.iter("body"))[0]:
-            if child.tag == 'p':
+        for child in list(root.iter(root.tag))[0]:
+            if child.tag == 'p' or child.tag == 'text':
                 caption = ''
 
                 # I think it will be faster than `len(list(child)) == 0`
@@ -111,10 +114,18 @@ class Caption:
                         caption += f' {s.text}'
                 caption = unescape(caption.replace("\n", " ").replace("  ", " "),)
                 try:
-                    duration = float(child.attrib["d"])/1000.0
+                    if "d" in child.attrib:
+                        duration = float(child.attrib["d"]) / 1000.0
+                    else:
+                        duration = float(child.attrib["dur"])
                 except KeyError:
                     duration = 0.0
-                start = float(child.attrib["t"])/1000.0
+
+                if "t" in child.attrib:
+                    start = float(child.attrib["t"]) / 1000.0
+                else:
+                    start = float(child.attrib["start"])
+
                 end = start + duration
                 sequence_number = i + 1  # convert from 0-indexed to 1.
                 line = "{seq}\n{start} --> {end}\n{text}\n".format(


### PR DESCRIPTION
## This PR fixes pytubefix issue with getting subtitles #81

- The **ANDROID_TESTSUITE** client is not being able to obtain subtitles in the innertube response, so now we will use the **WEB** client to obtain the subtitles.

- YouTube can change the xml body of subtitles, so the code was adapted to prevent problems.

- The `json_captions` method was also fixed, which was not able to obtain a valid response.