### PR TITLE
Fixed issue with use_oauth

### DIFF
--- a/pytubefix/exceptions.py
+++ b/pytubefix/exceptions.py
@@ -69,6 +69,35 @@ class AgeRestrictedError(VideoUnavailable):
         return f"{c.RED}Video ID = {self.video_id}: is age restricted, and can't be accessed without logging in.{c.RESET}"
 
 
+class AgeCheckRequiredError(VideoUnavailable):
+    def __init__(self, video_id: str):
+        """
+        :param str video_id:
+            A YouTube video identifier.
+        """
+        self.video_id = video_id
+        super().__init__(self.video_id)
+
+    @property
+    def error_string(self):
+        return f"{c.RED}Video ID = {self.video_id}: it has age restrictions and cannot be accessed without confirmation.{c.RESET}"
+
+
+class AgeCheckRequiredAccountError(VideoUnavailable):
+    def __init__(self, video_id: str):
+        """
+        :param str video_id:
+            A YouTube video identifier.
+        """
+        self.video_id = video_id
+        super().__init__(self.video_id)
+
+    @property
+    def error_string(self):
+        return (f"{c.RED}Video ID = {self.video_id}: Sorry, something is wrong. This video may be inappropriate for "
+                f"some users. Sign in to your primary account to confirm your age.{c.RESET}")
+
+
 class LiveStreamError(VideoUnavailable):
     """Video is a live stream."""
     def __init__(self, video_id: str):

--- a/pytubefix/extract.py
+++ b/pytubefix/extract.py
@@ -89,7 +89,7 @@ def is_age_restricted(watch_html: str) -> bool:
     return True
 
 
-def playability_status(watch_html: str) -> Tuple[Any, Any]:
+def playability_status(player_response: dict) -> Tuple[Any, Any]:
     """Return the playability status and status explanation of a video.
 
     For example, a video may have a status of LOGIN_REQUIRED, and an explanation
@@ -97,16 +97,20 @@ def playability_status(watch_html: str) -> Tuple[Any, Any]:
 
     This explanation is what gets incorporated into the media player overlay.
 
-    :param str watch_html:
-        The html contents of the watch page.
+    :param str player_response:
+        Content of the player's response.
     :rtype: bool
     :returns:
         Playability status and reason of the video.
     """
-    player_response = initial_player_response(watch_html)
     status_dict = player_response.get('playabilityStatus', {})
     if 'liveStreamability' in status_dict:
         return 'LIVE_STREAM', 'Video is a live stream.'
+
+    # Some clients do not have 'liveStreamability', so we check in videoDetails.
+    if player_response['videoDetails']['isLiveContent']:
+        return 'LIVE_STREAM', 'Video is a live stream.'
+
     if 'status' in status_dict:
         if 'reason' in status_dict:
             return status_dict['status'], [status_dict['reason']]

--- a/pytubefix/innertube.py
+++ b/pytubefix/innertube.py
@@ -600,8 +600,10 @@ class InnerTube:
         endpoint = f'{self.base_url}/verify_age'
         data = {
             'nextEndpoint': {
-                'urlEndpoint': {
-                    'url': f'/watch?v={video_id}'
+                'watchEndpoint': {
+                    'racyCheckOk': True,
+                    'contentCheckOk': True,
+                    'videoId': video_id
                 }
             },
             'setControvercy': True


### PR DESCRIPTION
# WARNING

Don't use your main account, YouTube may block your account if you use `use_oauth`, [see](https://github.com/yt-dlp/yt-dlp/issues/10085).

## Fixed issue with use_oauth #108 #110 

For age-restricted videos, YouTube requires us to confirm age, this is done by sending an endpoint.

So now `check_availability()` checks if YouTube returns an **AGE_CHECK_REQUIRED** and calls the `age_check()` function which sends the endpoint and requests the player again.

`age_check()` uses the **WEB** client due to its hitherto stability.

### Test before merging

From my tests, YouTube requires enpoint only once per account, so this makes some functionality tests difficult.