### PR TITLE
Use pathlib to correct behavior under Windows

### DIFF
--- a/pytubefix/streams.py
+++ b/pytubefix/streams.py
@@ -15,6 +15,7 @@ from datetime import datetime
 from typing import BinaryIO, Dict, Optional, Tuple
 from urllib.error import HTTPError
 from urllib.parse import parse_qs
+from pathlib import Path
 
 from pytubefix import extract, request
 from pytubefix.helpers import safe_filename, target_directory
@@ -363,7 +364,7 @@ class Stream:
             filename = self.default_filename
         if filename_prefix:
             filename = f"{filename_prefix}{filename}"
-        return os.path.join(target_directory(output_path), filename)
+        return str(Path(target_directory(output_path)) / filename)
 
     def exists_at_path(self, file_path: str) -> bool:
         return (


### PR DESCRIPTION
Qt Pyside functions to retrieve a local folder return paths with "/" under Windows. The use of os.path.join here was joining with "\", thus generating an incorrect path. Using Pathlib produces a path with "/" only.