### PR TITLE
Fix missing file extensions

### DIFF
--- a/pytubefix/cli.py
+++ b/pytubefix/cli.py
@@ -395,15 +395,17 @@ def _ffmpeg_downloader(audio_stream: Stream,
         "audio",
         target=target,
     )
-    _download(stream=video_stream, target=target, filename=video_unique_name)
+    video_filename = f"{video_unique_name}.{video_stream.subtype}"
+    _download(stream=video_stream, target=target, filename=video_filename)
     print("Loading audio...")
-    _download(stream=audio_stream, target=target, filename=audio_unique_name)
+    audio_filename = f"{audio_unique_name}.{audio_stream.subtype}"
+    _download(stream=audio_stream, target=target, filename=audio_filename)
 
     video_path = os.path.join(
-        target, f"{video_unique_name}.{video_stream.subtype}"
+        target, video_filename
     )
     audio_path = os.path.join(
-        target, f"{audio_unique_name}.{audio_stream.subtype}"
+        target, audio_filename
     )
     final_path = os.path.join(
         target, f"{safe_filename(video_stream.title)}.{video_stream.subtype}"


### PR DESCRIPTION
When using the CLI, the `-f` option would fail due to the downloaded files being created without extensions and ffmpeg being told to look for files that do have extensions. I've fixed this simply by passing the same filename to both the `_download` function and to ffmpeg. This was an easy enough fix that I figured I would just make a PR instead of creating an issue.