### PR TITLE
Improved performance on non-web clients

### DIFF
--- a/pytubefix/__main__.py
+++ b/pytubefix/__main__.py
@@ -243,17 +243,18 @@ class YouTube:
 
         stream_manifest = extract.apply_descrambler(self.streaming_data)
 
-        # If the cached js doesn't work, try fetching a new js file
-        # https://github.com/pytube/pytube/issues/1054
-        try:
-            extract.apply_signature(stream_manifest, self.vid_info, self.js)
-        except exceptions.ExtractError:
-            # To force an update to the js file, we clear the cache and retry
-            self._js = None
-            self._js_url = None
-            pytubefix.__js__ = None
-            pytubefix.__js_url__ = None
-            extract.apply_signature(stream_manifest, self.vid_info, self.js)
+        if InnerTube(self.client).require_js_player:
+            # If the cached js doesn't work, try fetching a new js file
+            # https://github.com/pytube/pytube/issues/1054
+            try:
+                extract.apply_signature(stream_manifest, self.vid_info, self.js)
+            except exceptions.ExtractError:
+                # To force an update to the js file, we clear the cache and retry
+                self._js = None
+                self._js_url = None
+                pytubefix.__js__ = None
+                pytubefix.__js_url__ = None
+                extract.apply_signature(stream_manifest, self.vid_info, self.js)
 
         # build instances of :class:`Stream <Stream>`
         # Initialize stream objects
@@ -369,10 +370,11 @@ class YouTube:
         """If the video has any age restrictions, you must confirm that you wish to continue.
 
         Here the WEB client is used to have better stability.
-
         """
+
+        self.client = 'WEB'
         innertube = InnerTube(
-            client='WEB',
+            client=self.client,
             use_oauth=self.use_oauth,
             allow_cache=self.allow_oauth_cache
         )


### PR DESCRIPTION
## Improved performance on non-web clients 

Since #94 YouTube seems to have reduced clients response times.

The `fmt_streams()` method was downloading **base.js** unnecessarily on all clients, currently only WEBs need it, so a check was added to deal with this.

### Results

I particularly had great results when getting all the streams:

* Before this PR I had an average of 4.842 seconds to get all streams.

* Now with this PR I have an average of 0.377 seconds.