### PR TITLE
Fix empty chapter list bug

### DIFF
--- a/pytubefix/__main__.py
+++ b/pytubefix/__main__.py
@@ -438,9 +438,13 @@ class YouTube:
         :rtype: List[Chapter]
         """
         try:
-            chapters_data = self.initial_data['playerOverlays']['playerOverlayRenderer'][
+            markers_map = self.initial_data['playerOverlays']['playerOverlayRenderer'][
                 'decoratedPlayerBarRenderer']['decoratedPlayerBarRenderer']['playerBar'][
-                'multiMarkersPlayerBarRenderer']['markersMap'][0]['value']['chapters']
+                'multiMarkersPlayerBarRenderer']['markersMap']
+            for marker in markers_map:
+                if marker['key'].upper() == 'DESCRIPTION_CHAPTERS':
+                    chapters_data = marker['value']['chapters']
+                    break
         except (KeyError, IndexError):
             return []
 


### PR DESCRIPTION
Pull request to fix [bug #130](https://github.com/JuanBindez/pytubefix/issues/130).

Some videos have the list of chapters later in `markersMap` but the code calls on the first item every time. By iterating through `markersMap` to look for the correct element instead of calling on [0] it should be fixed.

