### PR TITLE
Added optional parameter to obtain streams

### DIFF
--- a/pytubefix/query.py
+++ b/pytubefix/query.py
@@ -301,9 +301,12 @@ class StreamQuery(Sequence):
         """
         return self._filter([lambda s: s.audio_track_name == name])
 
-    def get_lowest_resolution(self) -> Optional[Stream]:
+    def get_lowest_resolution(self, progressive=True) -> Optional[Stream]:
         """Get lowest resolution stream that is a progressive mp4.
 
+        :param bool progressive:
+            Filter only progressive streams (video and audio in the same file), default is True.
+            Set False to get the adaptive stream (separate video and audio) at the lowest resolution
         :rtype: :class:`Stream <Stream>` or None
         :returns:
             The :class:`Stream <Stream>` matching the given itag or None if
@@ -311,21 +314,24 @@ class StreamQuery(Sequence):
 
         """
         return (
-            self.filter(progressive=True, subtype="mp4")
+            self.filter(progressive=progressive, subtype="mp4")
             .order_by("resolution")
             .first()
         )
 
-    def get_highest_resolution(self) -> Optional[Stream]:
+    def get_highest_resolution(self, progressive=True) -> Optional[Stream]:
         """Get highest resolution stream that is a progressive video.
 
+        :param bool progressive:
+            Filter only progressive streams (video and audio in the same file), default is True.
+            Set False to get the adaptive stream (separate video and audio) at the highest resolution
         :rtype: :class:`Stream <Stream>` or None
         :returns:
             The :class:`Stream <Stream>` matching the given itag or None if
             not found.
 
         """
-        return self.filter(progressive=True).order_by("resolution").last()
+        return self.filter(progressive=progressive).order_by("resolution").last()
 
     def get_audio_only(self, subtype: str = "mp4") -> Optional[Stream]:
         """Get highest bitrate audio stream for given codec (defaults to mp4)


### PR DESCRIPTION
## Added optional parameter to obtain streams #128 

YouTube provides streams in two different formats, progressive streams that provide video and audio in a single file, and adaptive streams that provide video and audio in separate files.

Currently YouTube clients only provide progressive streams in 360p resolution.

This PR adds an optional parameter to `get_highest_resolution()` and `get_lowest_resolution()`, which allows you to get adaptive stream.

### Example:

If I want the highest quality adaptive video, I just use:

```python
yt_url = 'https://www.youtube.com/watch?v=60ItHLz5WEA'
yt = YouTube(yt_url)

print(yt.streams.get_highest_resolution(progressive=False))
```

```
<Stream: itag="399" mime_type="video/mp4" res="1080p" fps="25fps" vcodec="av01.0.08M.08" progressive="False" type="video">
```

Observe that if the `progressive` value is not passed, it will return the progressive stream:

```python
yt_url = 'https://www.youtube.com/watch?v=60ItHLz5WEA'
yt = YouTube(yt_url)

print(yt.streams.get_highest_resolution())
```

```
<Stream: itag="18" mime_type="video/mp4" res="360p" fps="25fps" vcodec="avc1.42001E" acodec="mp4a.40.2" progressive="True" type="video">
```