### PR TITLE
Fix null chapters_data

### DIFF
--- a/pytubefix/__main__.py
+++ b/pytubefix/__main__.py
@@ -438,6 +438,7 @@ class YouTube:
         :rtype: List[Chapter]
         """
         try:
+            chapters_data = []
             markers_map = self.initial_data['playerOverlays']['playerOverlayRenderer'][
                 'decoratedPlayerBarRenderer']['decoratedPlayerBarRenderer']['playerBar'][
                 'multiMarkersPlayerBarRenderer']['markersMap']


### PR DESCRIPTION
Fix for bug 130 introduced new bug where `chapters_data` can be None which caused an `UnboundLocalError` Just added a line of code to initialize chapters_data first as an empty list beforehand. 