### PR TITLE
Fixed "slice must be applied on a list in: a.slice(0,0)"

### DIFF
--- a/pytubefix/jsinterp.py
+++ b/pytubefix/jsinterp.py
@@ -942,9 +942,9 @@ class JSInterpreter:
                     obj.reverse()
                     return obj
                 elif member == 'slice':
-                    assertion(isinstance(obj, list), 'must be applied on a list')
-                    assertion(len(argvals) == 1, 'takes exactly one argument')
-                    return obj[argvals[0]:]
+                    assertion(isinstance(obj, (list, str)), 'must be applied on a list or string')
+                    assertion(len(argvals) <= 2, 'takes between 0 and 2 arguments')
+                    return obj[slice(*argvals, None)]
                 elif member == 'splice':
                     assertion(isinstance(obj, list), 'must be applied on a list')
                     assertion(argvals, 'takes one or more arguments')


### PR DESCRIPTION
## Fixed "slice must be applied on a list in: a.slice(0,0)" #158 

The player [b12cc44b](https://www.youtube.com/s/player/b12cc44b/player_ias.vflset/en_US/base.js) broke the **jsinterp** method that deals with JavaScript `slice` methods.

jsinterp.py is responsible for interpreting the obfuscation function of parameter "n", if the interpretation fails, a 403 error is generated in all WEB-based streams.