### PR TITLE
Added bot detection exception

### DIFF
--- a/pytubefix/__main__.py
+++ b/pytubefix/__main__.py
@@ -217,7 +217,7 @@ class YouTube:
             # for each fallback client set, revert videodata, and run check_availability, which
             #   will try to get a new video_info with a different client.
             #   if it fails try the next fallback client, and so on.
-            # If none of the cleints have valid streamingData, raise an exception.
+            # If none of the clients have valid streamingData, raise an exception.
             for client in self.fallback_clients:
                 self.client = client
                 self.vid_info = None
@@ -228,7 +228,10 @@ class YouTube:
                 if 'streamingData' in self.vid_info:
                     break
             if 'streamingData' not in self.vid_info:
-                raise exceptions.UnknownVideoError(video_id=self.video_id,developer_message=f'Streaming data is missing, original client: {original_client}, fallback clients: {self.fallback_clients}')
+                raise exceptions.UnknownVideoError(video_id=self.video_id,
+                                                   developer_message=f'Streaming data is missing, '
+                                                                     f'original client: {original_client}, '
+                                                                     f'fallback clients: {self.fallback_clients}')
 
         return self.vid_info['streamingData']
 
@@ -306,8 +309,12 @@ class YouTube:
                         'Sign in to confirm your age'
                 ):
                     raise exceptions.AgeRestrictedError(video_id=self.video_id)
+                elif reason == (
+                        'Sign in to confirm you’re not a bot'
+                ):
+                    raise exceptions.BotDetection(video_id=self.video_id)
                 else:
-                    raise exceptions.LoginRequired(video_id=self.video_id)
+                    raise exceptions.LoginRequired(video_id=self.video_id, reason=reason)
 
             elif status == 'AGE_CHECK_REQUIRED':
                 if self.use_oauth:
@@ -374,6 +381,10 @@ class YouTube:
         innertube_response = innertube.player(self.video_id)
         self._vid_info = innertube_response
         return self._vid_info
+
+    @vid_info.setter
+    def vid_info(self, value):
+        self._vid_info = value
 
     def age_check(self):
         """If the video has any age restrictions, you must confirm that you wish to continue.

--- a/pytubefix/exceptions.py
+++ b/pytubefix/exceptions.py
@@ -2,9 +2,11 @@
 from typing import Pattern, Union
 from .colors import Color
 import logging
+
 logger = logging.getLogger(__name__)
 
 c = Color()
+
 
 class PytubeFixError(Exception):
     """Base pytube exception that all others inherit.
@@ -64,6 +66,7 @@ class VideoUnavailable(PytubeFixError):
 
     Call this if you can't group the error by known error type and it is not important to the developer.
     """
+
     def __init__(self, video_id: str):
         """
         :param str video_id:
@@ -101,6 +104,7 @@ class MembersOnly(VideoUnavailable):
     subscribed to a content creator.
     ref: https://support.google.com/youtube/answer/7544492?hl=en
     """
+
     def __init__(self, video_id: str):
         """
         :param str video_id:
@@ -127,7 +131,8 @@ class VideoRegionBlocked(VideoUnavailable):
     def error_string(self):
         return f'{c.RED}{self.video_id} is not available in your region{c.RESET}'
 
-class LoginRequired(VideoUnavailable):
+
+class BotDetection(VideoUnavailable):
     def __init__(self, video_id: str):
         """
         :param str video_id:
@@ -135,10 +140,26 @@ class LoginRequired(VideoUnavailable):
         """
         self.video_id = video_id
         super().__init__(self.video_id)
-    
+
     @property
     def error_string(self):
-        return f'{c.RED}{self.video_id} requires login to view{c.RESET}'
+        return f'{c.RED}{self.video_id} This request has been detected as a bot, please try again or log in to view{c.RESET}'
+
+
+class LoginRequired(VideoUnavailable):
+    def __init__(self, video_id: str, reason: str):
+        """
+        :param str video_id:
+            A YouTube video identifier.
+        """
+        self.video_id = video_id
+        self.reason = reason
+        super().__init__(self.video_id)
+
+    @property
+    def error_string(self):
+        return f'{c.RED}{self.video_id} requires login to view, reason: {self.reason}{c.RESET}'
+
 
 # legacy livestream error types still supported
 
@@ -158,6 +179,7 @@ class RecordingUnavailable(VideoUnavailable):
 
 class LiveStreamError(VideoUnavailable):
     """Video is a live stream."""
+
     def __init__(self, video_id: str):
         """
         :param str video_id:
@@ -175,6 +197,7 @@ class LiveStreamError(VideoUnavailable):
 
 class AgeRestrictedError(VideoUnavailable):
     """Video is age restricted, and cannot be accessed without OAuth."""
+
     def __init__(self, video_id: str):
         """
         :param str video_id:
@@ -222,7 +245,8 @@ class AgeCheckRequiredAccountError(VideoUnavailable):
 
 class UnknownVideoError(VideoUnavailable):
     """Unknown video error."""
-    def __init__(self, video_id: str, status: str=None, reason: str=None, developer_message: str=None):
+
+    def __init__(self, video_id: str, status: str = None, reason: str = None, developer_message: str = None):
         """
         :param str video_id:
             A YouTube video identifier.


### PR DESCRIPTION
## Added bot detection exception #157 #161 #166 

YouTube is working tirelessly to prevent ad blockers and third-party applications, so it may require a captcha to access the streams.

Most reports are from known VPN users, see more at [yt-dlp](https://github.com/yt-dlp/yt-dlp/issues/10128).

As this can occur even on official clients, there is no sure way to prevent this from happening, so we will have to log in using `oauth` or try to change IP.

### Changes

This PR adds an exception class that checks captcha detection and asks the user to try again or log in.

The `LoginRequired` class receives the `reason` parameter to facilitate debugging new errors.