### PR TITLE
Added login parameter to Playlist, Search and Channel

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,13 +1,9 @@
 #!/bin/bash
 
 git add .
-git commit -m 'Refactor code to ensure compatibility with Python 3.7
-
-- Replaced the 'int | None' type annotation with 'Optional[int]' to support older Python versions.
-- Imported 'Optional' from the 'typing' module.
-'
-git push -u origin dev
-git tag v6.11-rc1
+git commit -m 'Pytubefix 6.11.0 (#178)'
+git push -u origin main
+git tag v6.11.0
 git push --tag
 make clean
 make upload

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pytubefix"
-version = "6.11-rc1"
+version = "6.11.0"
 authors = [
   { name="Juan Bindez", email="juanbindez780@gmail.com" },
 ]

--- a/pytubefix/contrib/playlist.py
+++ b/pytubefix/contrib/playlist.py
@@ -17,17 +17,35 @@ class Playlist(Sequence):
     def __init__(
             self,
             url: str,
+            client: str = 'WEB',
             proxies: Optional[Dict[str, str]] = None,
             use_oauth: bool = False,
             allow_oauth_cache: bool = True,
-        ):
+            token_file: Optional[str] = None
+    ):
+        """
+        :param dict proxies:
+            (Optional) A dict mapping protocol to proxy address which will be used by pytube.
+        :param bool use_oauth:
+            (Optional) Prompt the user to authenticate to YouTube.
+            If allow_oauth_cache is set to True, the user should only be prompted once.
+        :param bool allow_oauth_cache:
+            (Optional) Cache OAuth tokens locally on the machine. Defaults to True.
+            These tokens are only generated if use_oauth is set to True as well.
+        :param str token_file:
+            (Optional) Path to the file where the OAuth tokens will be stored.
+            Defaults to None, which means the tokens will be stored in the pytubefix/__cache__ directory.
+        """
         if proxies:
             install_proxy(proxies)
 
         self._input_url = url
 
+        self.client = client
         self.use_oauth = use_oauth
         self.allow_oauth_cache = allow_oauth_cache
+        self.token_file = token_file
+
         # These need to be initialized as None for the properties.
         self._html = None
         self._ytcfg = None
@@ -311,7 +329,8 @@ class Playlist(Sequence):
             yield YouTube(
                 url,
                 use_oauth=self.use_oauth,
-                allow_oauth_cache=self.allow_oauth_cache
+                allow_oauth_cache=self.allow_oauth_cache,
+                token_file=self.token_file
             )
 
     @property

--- a/pytubefix/version.py
+++ b/pytubefix/version.py
@@ -1,4 +1,4 @@
-__version__ = "6.11-rc1"
+__version__ = "6.11.0"
 
 if __name__ == "__main__":
     print(__version__)


### PR DESCRIPTION
## Added login parameter to Playlist, Search and Channel

With the implementation of the **proof of origin token (PoToken)**, multiple users may receive a bot detection error.

As there is still no solution to bypass PoToken, we should try logging in using `use_oauth=True`, or try using a proxy to change the IP.

### Changes:

This PR adds optional parameters necessary to log in or use a proxy in the `Playlist`, `Channel` and `Search` classes.
