### PR TITLE
Added outh_verifier

### DIFF
--- a/pytubefix/__main__.py
+++ b/pytubefix/__main__.py
@@ -58,6 +58,7 @@ class YouTube:
             use_oauth: bool = False,
             allow_oauth_cache: bool = True,
             token_file: Optional[str] = None,
+            outh_verifier: Callable[[str, str], None]|None=None
     ):
         """Construct a :class:`YouTube <YouTube>`.
 
@@ -87,6 +88,10 @@ class YouTube:
         :param str token_file:
             (Optional) Path to the file where the OAuth tokens will be stored.
             Defaults to None, which means the tokens will be stored in the pytubefix/__cache__ directory.
+        :param Callable outh_verifier:
+            (optional) Verifier to be used for getting outh tokens. 
+            Verification URL and User-Code will be passed to it respectively.
+            (if passed, else default verifier will be used)
         """
         # js fetched by js_url
         self._js: Optional[str] = None
@@ -137,6 +142,7 @@ class YouTube:
         self.use_oauth = use_oauth
         self.allow_oauth_cache = allow_oauth_cache
         self.token_file = token_file
+        self.outh_verifier = outh_verifier
 
     def __repr__(self):
         return f'<pytubefix.__main__.YouTube object: videoId={self.video_id}>'
@@ -374,6 +380,7 @@ class YouTube:
             use_oauth=self.use_oauth,
             allow_cache=self.allow_oauth_cache,
             token_file=self.token_file,
+            outh_verifier=self.outh_verifier
         )
         if innertube.require_js_player:
             innertube.innertube_context.update(self.signature_timestamp)
@@ -398,6 +405,7 @@ class YouTube:
             use_oauth=self.use_oauth,
             allow_cache=self.allow_oauth_cache,
             token_file=self.token_file,
+            outh_verifier=self.outh_verifier
         )
 
         if innertube.require_js_player:

--- a/pytubefix/innertube.py
+++ b/pytubefix/innertube.py
@@ -414,10 +414,17 @@ _cache_dir = pathlib.Path(__file__).parent.resolve() / '__cache__'
 _token_file = os.path.join(_cache_dir, 'tokens.json')
 
 
+def _default_outh_verifier(verification_url: str, user_code: str):
+    """ Default `print(...)` and `input(...)` for outh verification """
+    print(f'Please open {verification_url} and input code {user_code}')
+    input('Press enter when you have completed this step.')
+
+
+
 class InnerTube:
     """Object for interacting with the innertube API."""
 
-    def __init__(self, client='ANDROID_TESTSUITE', use_oauth=False, allow_cache=True, token_file=None):
+    def __init__(self, client='ANDROID_TESTSUITE', use_oauth=False, allow_cache=True, token_file=None, outh_verifier=None):
         """Initialize an InnerTube object.
 
         :param str client:
@@ -428,6 +435,10 @@ class InnerTube:
             Whether or not to authenticate to YouTube.
         :param bool allow_cache:
             Allows caching of oauth tokens on the machine.
+        :param Callable outh_verifier:
+            Verifier to be used for getting outh tokens. 
+            Verification URL and User-Code will be passed to it respectively. 
+            (if passed, else default verifier will be used)
         """
         self.innertube_context = _default_clients[client]['innertube_context']
         self.header = _default_clients[client]['header']
@@ -437,6 +448,7 @@ class InnerTube:
         self.refresh_token = None
         self.use_oauth = use_oauth
         self.allow_cache = allow_cache
+        self.outh_verifier = outh_verifier or _default_outh_verifier
 
         # Stored as epoch time
         self.expires = None
@@ -519,8 +531,7 @@ class InnerTube:
         response_data = json.loads(response.read())
         verification_url = response_data['verification_url']
         user_code = response_data['user_code']
-        print(f'Please open {verification_url} and input code {user_code}')
-        input('Press enter when you have completed this step.')
+        self.outh_verifier(verification_url, user_code)
 
         data = {
             'client_id': _client_id,


### PR DESCRIPTION
Verifier to be used for getting outh tokens.
Verification URL and User-Code will be passed to it respectively. (if passed, else default verifier will be used)

Basically,
- By default, it just prints the code and waits for input.
- Now a callable can be passed to catch those values and manage as user fits, for example showing in a UI.