### PR TITLE
Added country availability exception

### DIFF
--- a/pytubefix/__main__.py
+++ b/pytubefix/__main__.py
@@ -307,6 +307,10 @@ class YouTube:
                         'Sign in to your primary account to confirm your age.'
                 ):
                     raise exceptions.AgeCheckRequiredAccountError(video_id=self.video_id)
+                elif reason == (
+                        'The uploader has not made this video available in your country'
+                ):
+                    raise exceptions.VideoRegionBlocked(video_id=self.video_id)
                 else:
                     raise exceptions.VideoUnavailable(video_id=self.video_id)
 


### PR DESCRIPTION
## Added country availability exception

Pytubefix has the `VideoRegionBlocked` exception class, but it was not being used.

Before, only a video is unavailable error was shown.

This PR implements this class in `check_availability`, now showing the message: _**is not available in your region**_.

