### PR TITLE
Improved compatibility with Python 3.6+

### DIFF
--- a/pytubefix/__main__.py
+++ b/pytubefix/__main__.py
@@ -31,7 +31,7 @@ smaller peripheral modules and functions.
 """
 
 import logging
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import pytubefix
 import pytubefix.exceptions as exceptions
@@ -60,7 +60,7 @@ class YouTube:
             token_file: Optional[str] = None,
             oauth_verifier: Optional[Callable[[str, str], None]] = None,
             use_po_token: Optional[bool] = False,
-            po_token_verifier: Optional[Callable[[None], tuple[str, str]]] = None,
+            po_token_verifier: Optional[Callable[[None], Tuple[str, str]]] = None,
     ):
         """Construct a :class:`YouTube <YouTube>`.
 

--- a/pytubefix/contrib/channel.py
+++ b/pytubefix/contrib/channel.py
@@ -21,7 +21,7 @@ class Channel(Playlist):
             token_file: Optional[str] = None,
             oauth_verifier: Optional[Callable[[str, str], None]] = None,
             use_po_token: Optional[bool] = False,
-            po_token_verifier: Optional[Callable[[None], tuple[str, str]]] = None,
+            po_token_verifier: Optional[Callable[[None], Tuple[str, str]]] = None,
     ):
         """Construct a :class:`Channel <Channel>`.
         :param str url:

--- a/pytubefix/contrib/playlist.py
+++ b/pytubefix/contrib/playlist.py
@@ -24,7 +24,7 @@ class Playlist(Sequence):
             token_file: Optional[str] = None,
             oauth_verifier: Optional[Callable[[str, str], None]] = None,
             use_po_token: Optional[bool] = False,
-            po_token_verifier: Optional[Callable[[None], tuple[str, str]]] = None,
+            po_token_verifier: Optional[Callable[[None], Tuple[str, str]]] = None,
     ):
         """
         :param dict proxies:

--- a/pytubefix/contrib/search.py
+++ b/pytubefix/contrib/search.py
@@ -1,7 +1,7 @@
 """Module for interacting with YouTube search."""
 # Native python imports
 import logging
-from typing import List, Optional, Dict, Callable
+from typing import List, Optional, Dict, Callable, Tuple
 
 # Local imports
 from pytubefix import YouTube, Channel, Playlist
@@ -21,7 +21,7 @@ class Search:
             token_file: Optional[str] = None,
             oauth_verifier: Optional[Callable[[str, str], None]] = None,
             use_po_token: Optional[bool] = False,
-            po_token_verifier: Optional[Callable[[None], tuple[str, str]]] = None,
+            po_token_verifier: Optional[Callable[[None], Tuple[str, str]]] = None,
     ):
         """Initialize Search object.
 

--- a/pytubefix/innertube.py
+++ b/pytubefix/innertube.py
@@ -9,6 +9,7 @@ import json
 import os
 import pathlib
 import time
+from typing import Tuple
 from urllib import parse
 
 # Local imports
@@ -420,7 +421,7 @@ def _default_oauth_verifier(verification_url: str, user_code: str):
     input('Press enter when you have completed this step.')
 
 
-def _default_po_token_verifier() -> tuple[str, str]:
+def _default_po_token_verifier() -> Tuple[str, str]:
     """
     Requests the visitorData and po_token with an input and returns a tuple[visitorData: str, po_token: str]
     """


### PR DESCRIPTION
## PR #209  caused typing error in old python versions.

The main cause of the errors was the type annotation that needs to be imported into the class in Python versions prior to 3.9.
