### PR TITLE
[Shorts] fixed KeyError: 'reelItemRenderer'

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 git add .
-git commit -m 'Pytubefix 6.15.1 (Fixed -> SyntaxError: f-string: unmatched '[' #213)'
+git commit -m 'Pytubefix 6.15.2 (#215)'
 git push -u origin main
-git tag v6.15.1
+git tag v6.15.2
 git push --tag
 make clean
 make upload

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pytubefix"
-version = "6.15.1"
+version = "6.15.2"
 authors = [
   { name="Juan Bindez", email="juanbindez780@gmail.com" },
 ]

--- a/pytubefix/contrib/search.py
+++ b/pytubefix/contrib/search.py
@@ -48,8 +48,8 @@ class Search:
             then passed as a `po_token` query parameter to affected clients.
             If allow_oauth_cache is set to True, the user should only be prompted once.
         :param Callable po_token_verifier:
-            (Optional) Verified used to obtain the visitorData and po_tokenoken.
-            The verifier will return the visitorData and po_tokenoken respectively.
+            (Optional) Verified used to obtain the visitorData and po_token.
+            The verifier will return the visitorData and po_token respectively.
             (if passed, else default verifier will be used)
         """
         self.query = query
@@ -306,8 +306,13 @@ class Search:
                 # Get shorts results
                 if 'reelShelfRenderer' in video_details:
                     for items in video_details['reelShelfRenderer']['items']:
-                        shorts.append(YouTube(f"https://www.youtube.com/watch?v="
-                                              f"{items['reelItemRenderer']['videoId']}",
+                        if 'reelItemRenderer' in items:
+                            video_id = items['reelItemRenderer']['videoId']
+                        else:
+                            video_id = items['shortsLockupViewModel']['inlinePlayerData']['onVisible'][
+                                'innertubeCommand']['watchEndpoint']['videoId']
+
+                        shorts.append(YouTube(f"https://www.youtube.com/watch?v={video_id}",
                                               use_oauth=self.use_oauth,
                                               allow_oauth_cache=self.allow_oauth_cache,
                                               token_file=self.token_file,

--- a/pytubefix/version.py
+++ b/pytubefix/version.py
@@ -1,4 +1,4 @@
-__version__ = "6.15.1"
+__version__ = "6.15.2"
 
 if __name__ == "__main__":
     print(__version__)


### PR DESCRIPTION
## Fixed KeyError: 'reelItemRenderer' #214 

YouTube updated the json structure that contains the video id.

Now some requests can return the id within the `shortsLockupViewModel` json object.

This PR adds verification of this new structure and retrieves the video id.