### PR TITLE
[Streams] Fixed missing video height

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 git add .
-git commit -m 'Pytubefix 6.15.1 (Fixed -> SyntaxError: f-string: unmatched '[' #213)'
+git commit -m 'Pytubefix 6.15.2 (#215)'
 git push -u origin main
-git tag v6.15.1
+git tag v6.15.2
 git push --tag
 make clean
 make upload

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pytubefix"
-version = "6.15.1"
+version = "6.15.2"
 authors = [
   { name="Juan Bindez", email="juanbindez780@gmail.com" },
 ]

--- a/pytubefix/streams.py
+++ b/pytubefix/streams.py
@@ -85,10 +85,10 @@ class Stream:
         self.resolution = itag_profile[
             "resolution"
         ]  # resolution (e.g.: "480p")
-        if 'width' in stream:
-            self.width = stream["width"]
-        if 'height' in stream:
-            self.width = stream["height"]
+
+        self._width = stream["width"] if 'width' in stream else None
+        self._height = stream["height"] if 'height' in stream else None
+
         self.is_3d = itag_profile["is_3d"]
         self.is_hdr = itag_profile["is_hdr"]
         self.is_live = itag_profile["is_live"]
@@ -157,6 +157,26 @@ class Stream:
         elif self.includes_audio_track:
             audio = self.codecs[0]
         return video, audio
+
+    @property
+    def width(self) -> int:
+        """Video width. Returns None if it does not have the value.
+
+        :rtype: int
+        :returns:
+            Returns an int of the video width
+        """
+        return self._width
+
+    @property
+    def height(self) -> int:
+        """Video height. Returns None if it does not have the value.
+
+        :rtype: int
+        :returns:
+            Returns an int of the video height
+        """
+        return self._height
 
     @property
     def filesize(self) -> int:

--- a/pytubefix/version.py
+++ b/pytubefix/version.py
@@ -1,4 +1,4 @@
-__version__ = "6.15.1"
+__version__ = "6.15.2"
 
 if __name__ == "__main__":
     print(__version__)


### PR DESCRIPTION
Close #210 

There was a small error that assigned the `height` of the video to the `width` property.

This PR also adds `width` and `height` access through getters.