### PR TITLE
Add interrupt_checker to allow interrupting downloads in progress

### DIFF
--- a/pytubefix/streams.py
+++ b/pytubefix/streams.py
@@ -12,7 +12,7 @@ import os
 from math import ceil
 
 from datetime import datetime
-from typing import BinaryIO, Dict, Optional, Tuple, Iterator
+from typing import BinaryIO, Dict, Optional, Tuple, Iterator, Callable
 from urllib.error import HTTPError
 from urllib.parse import parse_qs
 from pathlib import Path
@@ -270,15 +270,18 @@ class Stream:
         return f"{filename}.{self.subtype}"
 
 
-    def download(self,
-                output_path: Optional[str] = None,
-                filename: Optional[str] = None,
-                filename_prefix: Optional[str] = None,
-                skip_existing: bool = True,
-                timeout: Optional[int] = None,
-                max_retries: Optional[int] = 0,
-                mp3: bool = False,
-                remove_problematic_character: str = None) -> str:
+    def download(
+        self,
+        output_path: Optional[str] = None,
+        filename: Optional[str] = None,
+        filename_prefix: Optional[str] = None,
+        skip_existing: bool = True,
+        timeout: Optional[int] = None,
+        max_retries: int = 0,
+        mp3: bool = False,
+        remove_problematic_character: Optional[str] = None,
+        interrupt_checker: Optional[Callable[[], bool]] = None
+    ) -> str|None:
         
         """
         Download the file from the URL provided by `self.url`.
@@ -292,6 +295,7 @@ class Stream:
             max_retries (Optional[int]): Maximum number of retries for the download.
             mp3 (bool): Whether the file to be downloaded is an MP3 audio file.
             remove_problematic_character (str): Characters to be removed from the filename, exemple (problematic_character="?").
+            interrupt_checker (Callable): It will be checked while downloading. When it returns True, download will be stopped without any errors.
 
         Returns:
             str: File path of the downloaded file.
@@ -338,6 +342,9 @@ class Stream:
                     timeout=timeout,
                     max_retries=max_retries
                 ):
+                    if interrupt_checker is not None and interrupt_checker() == True:
+                        logger.debug('interrupt_checker returned True, causing to force stop the downloading')
+                        return
                     # reduce the (bytes) remainder by the length of the chunk.
                     bytes_remaining -= len(chunk)
                     # send to the on_progress callback.
@@ -352,6 +359,9 @@ class Stream:
                     timeout=timeout,
                     max_retries=max_retries
                 ):
+                    if interrupt_checker is not None and interrupt_checker() == True:
+                        logger.debug('interrupt_checker returned True, causing to force stop the downloading')
+                        return
                     # reduce the (bytes) remainder by the length of the chunk.
                     bytes_remaining -= len(chunk)
                     # send to the on_progress callback.


### PR DESCRIPTION
Added a new `interrupt_checker` parameter to the `download` function, enabling the download process to be interrupted gracefully. Key changes include:

- **`interrupt_checker` parameter**: Accepts a callable that is checked time to time during the download process. If it returns `True`, the download stops without raising errors.
- Ensures clean interruption without losing progress.
- No changes in default behavior unless `interrupt_checker` is passed.

### Other Updates:
- Updated the docstring of the `download` function to reflect the new parameter.
- Added logging for when the `interrupt_checker` triggers the download to stop.

This feature is useful for applications needing to stop downloads on user commands or specific conditions without generating errors.






