### PR TITLE
[Search] fix key error inlinePlayerData

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 git add .
-git commit -m 'rc2'
-git push -u origin dev
-git tag v6.16-rc2
+git commit -m 'Pytubefix 6.16.1 (#218 #223)'
+git push -u origin main
+git tag v6.16.1
 git push --tag
 make clean
 make upload

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pytubefix"
-version = "6.16-rc2"
+version = "6.16.1"
 authors = [
   { name="Juan Bindez", email="juanbindez780@gmail.com" },
 ]

--- a/pytubefix/contrib/search.py
+++ b/pytubefix/contrib/search.py
@@ -309,8 +309,8 @@ class Search:
                         if 'reelItemRenderer' in items:
                             video_id = items['reelItemRenderer']['videoId']
                         else:
-                            video_id = items['shortsLockupViewModel']['inlinePlayerData']['onVisible'][
-                                'innertubeCommand']['watchEndpoint']['videoId']
+                            video_id = items['shortsLockupViewModel']['onTap']['innertubeCommand'][
+                                'reelWatchEndpoint']['videoId']
 
                         shorts.append(YouTube(f"https://www.youtube.com/watch?v={video_id}",
                                               use_oauth=self.use_oauth,

--- a/pytubefix/version.py
+++ b/pytubefix/version.py
@@ -1,4 +1,4 @@
-__version__ = "6.16-rc2"
+__version__ = "6.16.1"
 
 if __name__ == "__main__":
     print(__version__)


### PR DESCRIPTION
Fix #227 

Recently YouTube updated the json tree for shorts, it is now possible to obtain the video IDs through 2 paths, `onTap` and `inlinePlayerData`, but it seems that the onTap path is more stable.