### PR TITLE
Fix for token's directory

### DIFF
--- a/pytubefix/innertube.py
+++ b/pytubefix/innertube.py
@@ -520,8 +520,9 @@ class InnerTube:
             'visitorData': self.access_visitorData,
             'po_token': self.access_po_token
         }
-        if not os.path.exists(_cache_dir):
-            os.mkdir(_cache_dir)
+        cacheDir = os.path.dirname(self.token_file)
+        if not os.path.exists(cacheDir):
+            os.makedirs(cacheDir, exist_ok=True)
         with open(self.token_file, 'w') as f:
             json.dump(data, f)
 


### PR DESCRIPTION
- It was not considering the tokens file provided in `YouTube.__init__()` -> _**fixed**_
- It was not generating the cache directory if any intermediate directory was missing -> _**fixed**_