### PR TITLE
Added getting likes

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 git add .
-git commit -m 'Pytubefix 6.16.2 (#228)'
+git commit -m 'Pytubefix 6.16.3 (#237)'
 git push -u origin main
-git tag v6.16.2
+git tag v6.16.3
 git push --tag
 make clean
 make upload

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pytubefix"
-version = "6.16.2"
+version = "6.16.3"
 authors = [
   { name="Juan Bindez", email="juanbindez780@gmail.com" },
 ]

--- a/pytubefix/innertube.py
+++ b/pytubefix/innertube.py
@@ -727,14 +727,28 @@ class InnerTube:
         ...
         # return self._call_api(endpoint, query, self.base_data)  # noqa:E800
 
-    def next(self):
+    def next(self, video_id: str = None, continuation: str = None):
         """Make a request to the next endpoint.
 
-        TODO: Figure out how we can use this
+        :param str video_id:
+            The video id to get player details for.
+        :param str continuation:
+            Continuation token if there is pagination
+        :rtype: dict
+        :returns:
+            Raw player details results.
         """
-        # endpoint = f'{self.base_url}/next'  # noqa:E800
-        ...
-        # return self._call_api(endpoint, query, self.base_data)  # noqa:E800
+
+        if continuation:
+            self.base_data.update({"continuation": continuation})
+
+        if video_id:
+            self.base_data.update({'videoId': video_id, 'contentCheckOk': "true"})
+
+        endpoint = f'{self.base_url}/next'
+        query = self.base_params
+
+        return self._call_api(endpoint, query, self.base_data)
 
     def player(self, video_id):
         """Make a request to the player endpoint.

--- a/pytubefix/version.py
+++ b/pytubefix/version.py
@@ -1,4 +1,4 @@
-__version__ = "6.16.2"
+__version__ = "6.16.3"
 
 if __name__ == "__main__":
     print(__version__)


### PR DESCRIPTION
## Added support for getting the number of likes for a video #224 

The official player sends a request to the `next` endpoint right after receiving the data from the `player` endpoint. This second call returns some data from the video, most of which is found in the player.

Here the most interesting thing is the number of likes, so for now the `next` endpoint will only be used for this.