### PR TITLE
Changed default client to ANDROID_VR

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 git add .
-git commit -m 'rc-1 6.17'
-git push -u origin dev
-git tag v6.17-rc1
+git commit -m 'Pytubefix 6.17.0 (#241)'
+git push -u origin main
+git tag v6.17.0
 git push --tag
 make clean
 make upload

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pytubefix"
-version = "6.17-rc1"
+version = "6.17.0"
 authors = [
   { name="Juan Bindez", email="juanbindez780@gmail.com" },
 ]

--- a/pytubefix/__main__.py
+++ b/pytubefix/__main__.py
@@ -456,10 +456,10 @@ class YouTube:
     def age_check(self):
         """If the video has any age restrictions, you must confirm that you wish to continue.
 
-        Here the WEB client is used to have better stability.
+        Originally the WEB client was used, but with the implementation of PoToken we switched to MWEB.
         """
 
-        self.client = 'WEB'
+        self.client = 'MWEB'
         innertube = InnerTube(
             client=self.client,
             use_oauth=self.use_oauth,

--- a/pytubefix/__main__.py
+++ b/pytubefix/__main__.py
@@ -51,7 +51,7 @@ class YouTube:
     def __init__(
             self,
             url: str,
-            client: str = 'ANDROID_TESTSUITE',
+            client: str = 'ANDROID_VR',
             on_progress_callback: Optional[Callable[[Any, bytes, int], None]] = None,
             on_complete_callback: Optional[Callable[[Any, Optional[str]], None]] = None,
             proxies: Optional[Dict[str, str]] = None,

--- a/pytubefix/__main__.py
+++ b/pytubefix/__main__.py
@@ -311,6 +311,10 @@ class YouTube:
         """
         status, messages = extract.playability_status(self.vid_info)
 
+        if InnerTube(self.client).require_po_token and not self.po_token:
+            logger.warning(f"The {self.client} client requires PoToken to obtain functional streams, "
+                           f"See more details at https://github.com/JuanBindez/pytubefix/pull/209")
+
         for reason in messages:
             if status == 'UNPLAYABLE':
                 if reason == (
@@ -367,7 +371,7 @@ class YouTube:
                     raise exceptions.UnknownVideoError(video_id=self.video_id, status=status, reason=reason, developer_message=f'Unknown reason type for Error status')
             elif status == 'LIVE_STREAM':
                 raise exceptions.LiveStreamError(video_id=self.video_id)
-            elif status == None:
+            elif status is None:
                 pass
             else:
                 raise exceptions.UnknownVideoError(video_id=self.video_id, status=status, reason=reason, developer_message=f'Unknown video status')

--- a/pytubefix/exceptions.py
+++ b/pytubefix/exceptions.py
@@ -143,7 +143,26 @@ class BotDetection(VideoUnavailable):
 
     @property
     def error_string(self):
-        return f'{c.RED}{self.video_id} This request was detected as a bot. Use `use_po_token=True` to view{c.RESET}'
+        return (f'{c.RED}{self.video_id} This request was detected as a bot. Use `use_po_token=True` to view. '
+                f'See more details at https://github.com/JuanBindez/pytubefix/pull/209{c.RESET}')
+
+
+class PoTokenRequired(VideoUnavailable):
+    def __init__(self, video_id: str, client_name: str):
+        """
+        :param str video_id:
+            A YouTube video identifier.
+        :param str client_name:
+            A YouTube client identifier.
+        """
+        self.video_id = video_id
+        self.client_name = client_name
+        super().__init__(self.video_id)
+
+    @property
+    def error_string(self):
+        return (f'{c.RED}{self.video_id} The {self.client_name} client requires PoToken to obtain functional streams, '
+                f'See more details at https://github.com/JuanBindez/pytubefix/pull/209{c.RESET}')
 
 
 class LoginRequired(VideoUnavailable):
@@ -158,7 +177,7 @@ class LoginRequired(VideoUnavailable):
 
     @property
     def error_string(self):
-        return f'{c.RED}{self.video_id} requires login to view, reason: {self.reason}{c.RESET}'
+        return f'{c.RED}{self.video_id} requires login to view, YouTube reason: {self.reason}{c.RESET}'
 
 
 # legacy livestream error types still supported

--- a/pytubefix/innertube.py
+++ b/pytubefix/innertube.py
@@ -49,7 +49,8 @@ _default_clients = {
             'X-Youtube-Client-Version': '2.20240709.01.00'
         },
         'api_key': 'AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8',
-        'require_js_player': True
+        'require_js_player': True,
+        'require_po_token': True
     },
 
     'WEB_EMBED': {
@@ -69,7 +70,8 @@ _default_clients = {
             'X-Youtube-Client-Name': '56'
         },
         'api_key': 'AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8',
-        'require_js_player': True
+        'require_js_player': True,
+        'require_po_token': False
     },
 
     'WEB_MUSIC': {
@@ -86,7 +88,8 @@ _default_clients = {
             'X-Youtube-Client-Name': '67'
         },
         'api_key': 'AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8',
-        'require_js_player': True
+        'require_js_player': True,
+        'require_po_token': False
     },
 
     'WEB_CREATOR': {
@@ -103,7 +106,8 @@ _default_clients = {
             'X-Youtube-Client-Name': '62'
         },
         'api_key': 'AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8',
-        'require_js_player': True
+        'require_js_player': True,
+        'require_po_token': False
     },
 
     'WEB_SAFARI': {
@@ -120,7 +124,8 @@ _default_clients = {
             'X-Youtube-Client-Name': '1'
         },
         'api_key': 'AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8',
-        'require_js_player': True
+        'require_js_player': True,
+        'require_po_token': True
     },
 
     'MWEB': {
@@ -137,7 +142,8 @@ _default_clients = {
             'X-Youtube-Client-Name': '2'
         },
         'api_key': 'AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8',
-        'require_js_player': True
+        'require_js_player': True,
+        'require_po_token': False
     },
 
     'ANDROID': {
@@ -158,7 +164,8 @@ _default_clients = {
             'X-Youtube-Client-Name': '3'
         },
         'api_key': 'AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8',
-        'require_js_player': False
+        'require_js_player': False,
+        'require_po_token': True
     },
 
     # Deprecated
@@ -201,7 +208,8 @@ _default_clients = {
             'X-Youtube-Client-Name': '28'
         },
         'api_key': 'AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8',
-        'require_js_player': False
+        'require_js_player': False,
+        'require_po_token': False
     },
 
     'ANDROID_MUSIC': {
@@ -221,7 +229,8 @@ _default_clients = {
             'X-Youtube-Client-Name': '21'
         },
         'api_key': 'AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8',
-        'require_js_player': False
+        'require_js_player': False,
+        'require_po_token': False
     },
 
     'ANDROID_CREATOR': {
@@ -241,7 +250,8 @@ _default_clients = {
             'X-Youtube-Client-Name': '14'
         },
         'api_key': 'AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8',
-        'require_js_player': False
+        'require_js_player': False,
+        'require_po_token': False
     },
 
     'ANDROID_TESTSUITE': {
@@ -263,7 +273,8 @@ _default_clients = {
             'X-Youtube-Client-Version': '1.9'
         },
         'api_key': 'AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8',
-        'require_js_player': False
+        'require_js_player': False,
+        'require_po_token': False
     },
 
     'ANDROID_PRODUCER': {
@@ -283,7 +294,8 @@ _default_clients = {
             'X-Youtube-Client-Name': '91'
         },
         'api_key': 'AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8',
-        'require_js_player': False
+        'require_js_player': False,
+        'require_po_token': False
     },
 
     'IOS': {
@@ -305,7 +317,8 @@ _default_clients = {
             'X-Youtube-Client-Name': '5'
         },
         'api_key': 'AIzaSyB-63vPrdThhKuerbB2N_l7Kwwcxj6yUAc',
-        'require_js_player': False
+        'require_js_player': False,
+        'require_po_token': False
     },
 
     # Deprecated
@@ -350,7 +363,8 @@ _default_clients = {
             'X-Youtube-Client-Name': '26'
         },
         'api_key': 'AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8',
-        'require_js_player': False
+        'require_js_player': False,
+        'require_po_token': False
     },
 
     'IOS_CREATOR': {
@@ -371,7 +385,8 @@ _default_clients = {
             'X-Youtube-Client-Name': '15'
         },
         'api_key': 'AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8',
-        'require_js_player': False
+        'require_js_player': False,
+        'require_po_token': False
     },
 
     'TV_EMBED': {
@@ -390,7 +405,8 @@ _default_clients = {
             'X-Youtube-Client-Name': '85'
         },
         'api_key': 'AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8',
-        'require_js_player': True
+        'require_js_player': True,
+        'require_po_token': False
     },
 
     'MEDIA_CONNECT': {
@@ -407,7 +423,8 @@ _default_clients = {
             'X-Youtube-Client-Name': '95'
         },
         'api_key': 'AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8',
-        'require_js_player': False
+        'require_js_player': False,
+        'require_po_token': False
     }
 }
 _token_timeout = 1800
@@ -475,6 +492,7 @@ class InnerTube:
         self.header = _default_clients[client]['header']
         self.api_key = _default_clients[client]['api_key']
         self.require_js_player = _default_clients[client]['require_js_player']
+        self.require_po_token = _default_clients[client]['require_po_token']
         self.access_token = None
         self.refresh_token = None
 

--- a/pytubefix/innertube.py
+++ b/pytubefix/innertube.py
@@ -453,7 +453,7 @@ class InnerTube:
 
     def __init__(
             self,
-            client='ANDROID_TESTSUITE',
+            client='ANDROID_VR',
             use_oauth=False,
             allow_cache=True,
             token_file=None,

--- a/pytubefix/version.py
+++ b/pytubefix/version.py
@@ -1,4 +1,4 @@
-__version__ = "6.17-rc1"
+__version__ = "6.17.0"
 
 if __name__ == "__main__":
     print(__version__)


### PR DESCRIPTION
## Temporary fix for #220 #239 #242 

YouTube is blocking some requests to the `ANDROID_TESTSUITE` client, returning the video unavailable error.

We still have several working clients, but at the moment `ANDROID_VR` seems to be working best for our purposes so it will be used as the default client.

### Why use ANDROID_VR?
WEB-based clients need the signature cipher, we can do it but it is slow. IOS clients do not have progressive streams, that is, the audio and video are in separate files. Some ANDROID variations work well, but may cause false error detections. And the TV client does not play videos that cannot be embedded.

### Changes to this PR

- Changing the default ANDROID_TESTSUITE client to ANDROID_VR.
- Changing the WEB login client to MWEB (due to the use of the WEB PoToken).
- Now the user will receive a message informing the need for PoToken for clients who need it.