### PR TITLE
Fixed incorrect clients calls

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 git add .
-git commit -m 'v7 rc1 (#244)'
-git push -u origin dev
-git tag v7.0-rc1
+git commit -m 'Pytubefix 7.0.0 (#244)'
+git push -u origin main
+git tag v7.0.0
 git push --tag
 make clean
 make upload

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pytubefix"
-version = "7.0-rc1"
+version = "7.0.0"
 authors = [
   { name="Juan Bindez", email="juanbindez780@gmail.com" },
 ]

--- a/pytubefix/__main__.py
+++ b/pytubefix/__main__.py
@@ -51,7 +51,7 @@ class YouTube:
     def __init__(
             self,
             url: str,
-            client: str = 'ANDROID_VR',
+            client: str = InnerTube().client_name,
             on_progress_callback: Optional[Callable[[Any, bytes, int], None]] = None,
             on_complete_callback: Optional[Callable[[Any, Optional[str]], None]] = None,
             proxies: Optional[Dict[str, str]] = None,

--- a/pytubefix/contrib/channel.py
+++ b/pytubefix/contrib/channel.py
@@ -6,6 +6,7 @@ from typing import Dict, List, Optional, Tuple, Iterable, Any, Callable
 
 from pytubefix import extract, YouTube, Playlist, request
 from pytubefix.helpers import cache, uniqueify, DeferredGeneratorList
+from pytubefix.innertube import InnerTube
 
 logger = logging.getLogger(__name__)
 
@@ -14,7 +15,7 @@ class Channel(Playlist):
     def __init__(
             self,
             url: str,
-            client: str = 'WEB',
+            client: str = InnerTube().client_name,
             proxies: Optional[Dict[str, str]] = None,
             use_oauth: bool = False,
             allow_oauth_cache: bool = True,
@@ -351,6 +352,7 @@ class Channel(Playlist):
         try:
             return YouTube(f"/watch?v="
                            f"{x['richItemRenderer']['content']['videoRenderer']['videoId']}",
+                           client=self.client,
                            use_oauth=self.use_oauth,
                            allow_oauth_cache=self.allow_oauth_cache,
                            token_file=self.token_file,
@@ -376,6 +378,7 @@ class Channel(Playlist):
                 video_id = content['reelItemRenderer']['videoId']
 
             return YouTube(f"/watch?v={video_id}",
+                           client=self.client,
                            use_oauth=self.use_oauth,
                            allow_oauth_cache=self.allow_oauth_cache,
                            token_file=self.token_file,
@@ -394,6 +397,7 @@ class Channel(Playlist):
         try:
             return Playlist(f"/playlist?list="
                             f"{x['richItemRenderer']['content']['playlistRenderer']['playlistId']}",
+                            client=self.client,
                             use_oauth=self.use_oauth,
                             allow_oauth_cache=self.allow_oauth_cache,
                             token_file=self.token_file,
@@ -413,6 +417,7 @@ class Channel(Playlist):
         try:
             return YouTube(f"/watch?v="
                            f"{x['gridVideoRenderer']['videoId']}",
+                           client=self.client,
                            use_oauth=self.use_oauth,
                            allow_oauth_cache=self.allow_oauth_cache,
                            token_file=self.token_file,
@@ -431,6 +436,7 @@ class Channel(Playlist):
         try:
             return YouTube(f"/watch?v="
                            f"{x['reelItemRenderer']['videoId']}",
+                           client=self.client,
                            use_oauth=self.use_oauth,
                            allow_oauth_cache=self.allow_oauth_cache,
                            token_file=self.token_file,
@@ -449,6 +455,7 @@ class Channel(Playlist):
         try:
             return Playlist(f"/playlist?list="
                             f"{x['gridPlaylistRenderer']['playlistId']}",
+                            client=self.client,
                             use_oauth=self.use_oauth,
                             allow_oauth_cache=self.allow_oauth_cache,
                             token_file=self.token_file,
@@ -467,6 +474,7 @@ class Channel(Playlist):
         try:
             return Channel(f"/channel/"
                            f"{x['gridChannelRenderer']['channelId']}",
+                           client=self.client,
                            use_oauth=self.use_oauth,
                            allow_oauth_cache=self.allow_oauth_cache,
                            token_file=self.token_file,

--- a/pytubefix/contrib/playlist.py
+++ b/pytubefix/contrib/playlist.py
@@ -18,7 +18,7 @@ class Playlist(Sequence):
     def __init__(
             self,
             url: str,
-            client: str = 'WEB',
+            client: str = InnerTube().client_name,
             proxies: Optional[Dict[str, str]] = None,
             use_oauth: bool = False,
             allow_oauth_cache: bool = True,
@@ -185,7 +185,7 @@ class Playlist(Sequence):
         while continuation:  # there is an url found
             # requesting the next page of videos with the url generated from the
             # previous page, needs to be a post
-            req = InnerTube(self.client).browse(continuation=continuation, visitor_data=self._visitor_data)
+            req = InnerTube('WEB').browse(continuation=continuation, visitor_data=self._visitor_data)
             # extract up to 100 songs from the page loaded
             # returns another continuation if more videos are available
             videos_urls, continuation = self._extract_videos(req, context)
@@ -340,6 +340,7 @@ class Playlist(Sequence):
         for url in self.video_urls:
             yield YouTube(
                 url,
+                client=self.client,
                 use_oauth=self.use_oauth,
                 allow_oauth_cache=self.allow_oauth_cache,
                 token_file=self.token_file,

--- a/pytubefix/contrib/search.py
+++ b/pytubefix/contrib/search.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 class Search:
     def __init__(
             self, query: str,
-            client: str = 'WEB',
+            client: str = InnerTube().client_name,
             proxies: Optional[Dict[str, str]] = None,
             use_oauth: bool = False,
             allow_oauth_cache: bool = True,
@@ -63,7 +63,7 @@ class Search:
         self.po_token_verifier = po_token_verifier
 
         self._innertube_client = InnerTube(
-            client=self.client,
+            client='WEB',
             use_oauth=self.use_oauth,
             allow_cache=self.allow_oauth_cache,
             token_file=self.token_file,
@@ -283,6 +283,7 @@ class Search:
                 if 'playlistRenderer' in video_details:
                     playlist.append(Playlist(f"https://www.youtube.com/playlist?list="
                                              f"{video_details['playlistRenderer']['playlistId']}",
+                                             client=self.client,
                                              use_oauth=self.use_oauth,
                                              allow_oauth_cache=self.allow_oauth_cache,
                                              token_file=self.token_file,
@@ -295,6 +296,7 @@ class Search:
                 if 'channelRenderer' in video_details:
                     channel.append(Channel(f"https://www.youtube.com/channel/"
                                            f"{video_details['channelRenderer']['channelId']}",
+                                           client=self.client,
                                            use_oauth=self.use_oauth,
                                            allow_oauth_cache=self.allow_oauth_cache,
                                            token_file=self.token_file,
@@ -313,6 +315,7 @@ class Search:
                                 'reelWatchEndpoint']['videoId']
 
                         shorts.append(YouTube(f"https://www.youtube.com/watch?v={video_id}",
+                                              client=self.client,
                                               use_oauth=self.use_oauth,
                                               allow_oauth_cache=self.allow_oauth_cache,
                                               token_file=self.token_file,
@@ -325,6 +328,7 @@ class Search:
                 if 'videoRenderer' in video_details:
                     videos.append(YouTube(f"https://www.youtube.com/watch?v="
                                           f"{video_details['videoRenderer']['videoId']}",
+                                          client=self.client,
                                           use_oauth=self.use_oauth,
                                           allow_oauth_cache=self.allow_oauth_cache,
                                           token_file=self.token_file,

--- a/pytubefix/innertube.py
+++ b/pytubefix/innertube.py
@@ -496,6 +496,8 @@ class InnerTube:
         self.access_token = None
         self.refresh_token = None
 
+        self.client_name = client
+
         self.access_po_token = None
         self.access_visitorData = None
 

--- a/pytubefix/version.py
+++ b/pytubefix/version.py
@@ -1,4 +1,4 @@
-__version__ = "7.0-rc1"
+__version__ = "7.0.0"
 
 if __name__ == "__main__":
     print(__version__)


### PR DESCRIPTION
## Fixed incorrect clients calls #247 

When the client name was passed into the constructor of the `Playlist`, `Search` and `Channel` classes, it was also used for paging, but the paging token comes from the WEB client and this caused the error when changing it.

Although the WEB client requires PoToken to obtain valid streams, it is still very useful for other data without causing slowdowns.

### This PR changes:

- It uses the WEB client for pagination and the client passed by the user as the constructor of the YouTube objects, in the `Playlist`, `Search` and `Channel` classes.

- Now to change the default pytubefix client, just change it in the `innertube.py` constructor.

- Created `client_name` property in InnerTube to synchronize the default client for other classes.