### PR TITLE
Fixed KeyError: 'videoDetails'

### DIFF
--- a/pytubefix/extract.py
+++ b/pytubefix/extract.py
@@ -107,8 +107,9 @@ def playability_status(player_response: dict) -> Tuple[Any, Any]:
     # if 'liveStreamability' in status_dict:
     # We used liveStreamability to know if the video was live,
     # however some clients still return this parameter even if the video is already available
-    if 'isLive' in player_response['videoDetails']:
-        return 'LIVE_STREAM', 'Video is a live stream.'
+    if 'videoDetails' in player_response:  # Private videos do not contain videoDetails
+        if 'isLive' in player_response['videoDetails']:
+            return 'LIVE_STREAM', 'Video is a live stream.'
 
     if 'status' in status_dict:
         if 'reason' in status_dict:


### PR DESCRIPTION
## Fixed KeyError: 'videoDetails'

PR #253 had a bug that generated a key error for private videos, as they do not have videoDetails which is used to check if the video is live.

So now first we check if the video has the videoDetails.