### PR TITLE
Added LiveStreamOffline exception

### DIFF
--- a/pytubefix/__main__.py
+++ b/pytubefix/__main__.py
@@ -356,6 +356,9 @@ class YouTube:
                 else:
                     raise exceptions.AgeCheckRequiredError(video_id=self.video_id)
 
+            elif status == 'LIVE_STREAM_OFFLINE':
+                raise exceptions.LiveStreamOffline(video_id=self.video_id, reason=reason)
+
             elif status == 'ERROR':
                 if reason == 'Video unavailable':
                     raise exceptions.VideoUnavailable(video_id=self.video_id)

--- a/pytubefix/exceptions.py
+++ b/pytubefix/exceptions.py
@@ -212,6 +212,25 @@ class LiveStreamError(VideoUnavailable):
         return f'{c.RED}{self.video_id} is streaming live and cannot be loaded{c.RESET}'
 
 
+class LiveStreamOffline(VideoUnavailable):
+    """The live will start soon"""
+
+    def __init__(self, video_id: str, reason: str):
+        """
+        :param str video_id:
+            A YouTube video identifier.
+        :param str reason:
+            reason for the error
+        """
+        self.video_id = video_id
+        self.reason = reason
+        super().__init__(self.video_id)
+
+    @property
+    def error_string(self):
+        return f'{self.video_id} {self.reason}'
+
+
 # legacy age restricted error types still supported
 
 class AgeRestrictedError(VideoUnavailable):


### PR DESCRIPTION
## Added LiveStreamOffline exception

This new exception allows you to identify videos that are marked as **upcoming**, it will generate an error similar to: `This live event will begin in 12 minutes`.