### PR TITLE
Fixed files without extensions

### DIFF
--- a/pytubefix/streams.py
+++ b/pytubefix/streams.py
@@ -336,16 +336,13 @@ class Stream:
             - If `mp3` is True and `filename` is not provided, the title of the resource will be used as the filename, with an `.mp3` extension.
             - If `filename` is provided and `mp3` is True, the `.mp3` extension will be appended to the provided filename.
             - The `file_system` argument ensures that invalid characters specific to the chosen file system are removed from the filename before saving. For example:
-                - NTFS (Windows) does not allow characters like `\`, `/`, `?`, `:`, `*`, etc.
+                - NTFS (Windows) does not allow characters like `\\`, `/`, `?`, `:`, `*`, etc.
                 - ext4 (Linux) only restricts the `/` character.
                 - APFS (macOS) restricts the `:` character.
             - The `skip_existing` flag avoids redownloading if the file already exists in the target location.
             - The `interrupt_checker` allows for the download to be halted cleanly if certain conditions are met during the download process.
             - Download progress can be monitored using the `on_progress` callback, and the `on_complete` callback is triggered once the download is finished.
         """
-
-        translation_table = file_system_verify(file_system)
-        filename = self.title.translate(translation_table)
         
         if mp3:
             if filename is None:
@@ -357,6 +354,7 @@ class Stream:
             filename=filename,
             output_path=output_path,
             filename_prefix=filename_prefix,
+            file_system=file_system
         )
 
         if skip_existing and self.exists_at_path(file_path):
@@ -407,9 +405,11 @@ class Stream:
         filename: Optional[str] = None,
         output_path: Optional[str] = None,
         filename_prefix: Optional[str] = None,
+        file_system: str = 'NTFS'
     ) -> str:
         if not filename:
-            filename = self.default_filename
+            translation_table = file_system_verify(file_system)
+            filename = self.default_filename.translate(translation_table)
         if filename_prefix:
             filename = f"{filename_prefix}{filename}"
         return str(Path(target_directory(output_path)) / filename)


### PR DESCRIPTION
There is a small bug in the implementation of the problematic characters that causes the files to be downloaded without any prefix.

Reported in: [https://github.com/JuanBindez/pytubefix/pull/277#issuecomment-2408606267](https://github.com/JuanBindez/pytubefix/pull/277#issuecomment-2408606267)