### PR TITLE
Fixed [Error] downloading mp3 with Python and Pytubefix (#283)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 git add .
-git commit -m '8.0-rc5 (#277 #278 #280 #281 #282)'
-git push -u origin dev
-git tag v8.0-rc5
+git commit -m '8.0.0 (#277 #278 #280 #281 #282)'
+git push -u origin main
+git tag v8.0.0
 git push --tag
 make clean
 make upload

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pytubefix"
-version = "8.0-rc5"
+version = "8.0.0"
 authors = [
   { name="Juan Bindez", email="juanbindez780@gmail.com" },
 ]

--- a/pytubefix/streams.py
+++ b/pytubefix/streams.py
@@ -345,9 +345,12 @@ class Stream:
         
         if mp3:
             if filename is None:
-                filename = self.title + ".mp3"
-            else:
-                filename = filename + ".mp3"
+                translation_table = file_system_verify(file_system)
+                title = self.title.translate(translation_table)
+                filename = title + '.mp3'
+            elif filename:
+                translation_table = file_system_verify(file_system)
+                filename = filename.translate(translation_table) + '.mp3'
 
         file_path = self.get_file_path(
             filename=filename,

--- a/pytubefix/version.py
+++ b/pytubefix/version.py
@@ -1,4 +1,4 @@
-__version__ = "8.0-rc5"
+__version__ = "8.0.0"
 
 if __name__ == "__main__":
     print(__version__)


### PR DESCRIPTION
fixed #283 and now when calling the `mp3 `parameter it can now be used together with the `file_system` avoiding errors due to characters

```python
>>> ys.download(mp3=True, file_system='ext4')
```

In the case of error #283, by default, pytubefix already removes the characters that cause problems on Windows, so you don't need to pass the `file_system` parameter

```python
>>> ys.download(mp3=True)
```

