### PR TITLE
Adjusted for MPEG-4 AAC audio codec extension, from mp4 to m4a

### DIFF
--- a/pytubefix/cli.py
+++ b/pytubefix/cli.py
@@ -334,3 +334,4 @@ def display_streams(youtube: YouTube) -> None:
 
 if __name__ == "__main__":
     main()
+    

--- a/pytubefix/streams.py
+++ b/pytubefix/streams.py
@@ -288,6 +288,8 @@ class Stream:
         :returns:
             An os file system compatible filename.
         """
+        if 'audio' in self.mime_type:
+            self.subtype = "m4a"
         return f"{self.title}.{self.subtype}"
 
     def download(


### PR DESCRIPTION
Why the change?

* This extension is best suited for the codec.
* This prevents some operating systems from identifying the file as video, (Despite opening as audio they appear as video in directories)
* When only audio is downloaded, it will download as m4a