### PR TITLE
Fixed HTTP Error 400: Bad Request when using use_oauth

### DIFF
--- a/pytubefix/innertube.py
+++ b/pytubefix/innertube.py
@@ -389,6 +389,25 @@ _default_clients = {
         'require_po_token': False
     },
 
+    'TV': {
+        'innertube_context': {
+            'context': {
+                'client': {
+                    'clientName': 'TVHTML5',
+                    'clientVersion': '7.20240813.07.00',
+                    'platform': 'TV'
+                }
+            }
+        },
+        'header': {
+            'User-Agent': 'Mozilla/5.0',
+            'X-Youtube-Client-Name': '7'
+        },
+        'api_key': 'AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8',
+        'require_js_player': True,
+        'require_po_token': False
+    },
+
     'TV_EMBED': {
         'innertube_context': {
             'context': {


### PR DESCRIPTION
## Fixed HTTP Error 400: Bad Request when using use_oauth #327 

Initially, oauth was designed to log in only to `TV` clients, but for several years it could be used on other clients.

A recent update has resolved this and now only `TV` and `TV_EMBED` clients can use `oauth`.

So now when `use_oauth=True` is used the client will be switched to the `TV`.

TV-based clients do not return the video title via the `player` endpoint, so if the title is not found, it will be attempted to search the `next` endpoint

### Changes to this PR:

- Added `TV` client.

- Automatic change to `TV` client when using `use_oauth=True`

- When using the TV or TV_EMBED client, the video title will be fetched by the `next` endpoint