### PR TITLE
Add reset_cache function to delete the __cache__ directory

### DIFF
--- a/pytubefix/helpers.py
+++ b/pytubefix/helpers.py
@@ -6,6 +6,7 @@ import logging
 import os
 import re
 import warnings
+import shutil
 from typing import Any, Callable, Dict, List, Optional, TypeVar
 from urllib import request
 
@@ -333,7 +334,17 @@ def create_mock_html_json(vid_id) -> Dict[str, Any]:
     return html_data
 
 
-# Remove ANSI color codes from a colored string
 def strip_color_codes(input_str):
+    """Remove ANSI color codes from a colored string"""
     ansi_escape = re.compile(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])')
     return ansi_escape.sub('', input_str)
+
+
+def reset_cache():
+        """Reset the cache by deleting the __cache__ directory."""
+        cache_dir = os.path.join(os.path.dirname(__file__), '__cache__')
+        if os.path.exists(cache_dir) and os.path.isdir(cache_dir):
+            shutil.rmtree(cache_dir)
+            print(f"Cache directory '{cache_dir}' has been reset.")
+        else:
+            print(f"Cache directory '{cache_dir}' does not exist.")

--- a/pytubefix/helpers.py
+++ b/pytubefix/helpers.py
@@ -340,11 +340,39 @@ def strip_color_codes(input_str):
     return ansi_escape.sub('', input_str)
 
 
-def reset_cache():
-        """Reset the cache by deleting the __cache__ directory."""
-        cache_dir = os.path.join(os.path.dirname(__file__), '__cache__')
-        if os.path.exists(cache_dir) and os.path.isdir(cache_dir):
-            shutil.rmtree(cache_dir)
-            print(f"Cache directory '{cache_dir}' has been reset.")
-        else:
-            print(f"Cache directory '{cache_dir}' does not exist.")
+def reset_cache(verbose: bool = False):
+    """
+    Deletes the `__cache__` directory to reset the cache.
+
+    This function checks if the `__cache__` directory exists in the same directory 
+    as the script. If it exists and is a directory, it deletes it along with its contents. 
+    If the directory does not exist, it logs a message indicating that the cache directory 
+    is not present.
+
+    Parameters:
+        verbose (bool): If True, sets up logging at the DEBUG level. Default is False.
+
+    Behavior:
+        - When `verbose` is True, debug messages are logged, providing information about 
+          the existence and status of the cache directory.
+        - If `verbose` is False, no logging configuration is modified, and debug messages 
+          may not be shown unless logging is already configured externally.
+
+    Example:
+        >>> reset_cache(verbose=True)
+        # Logs detailed information about the cache reset process.
+
+    Raises:
+        None
+    """
+    
+    cache_dir = os.path.join(os.path.dirname(__file__), '__cache__')
+
+    if verbose:
+        setup_logger(level=logging.DEBUG)
+
+    if os.path.exists(cache_dir) and os.path.isdir(cache_dir):
+        shutil.rmtree(cache_dir)
+        logger.debug(f"Cache directory '{cache_dir}' has been reset.")
+    else:
+        logger.debug(f"Cache directory '{cache_dir}' does not exist.")

--- a/pytubefix/innertube.py
+++ b/pytubefix/innertube.py
@@ -12,8 +12,8 @@ import time
 from typing import Tuple
 from urllib import parse
 
-# Local imports
 from pytubefix import request
+from pytubefix.helpers import reset_cache
 
 # YouTube on TV client secrets
 _client_id = '861556708454-d6dlm3lh05idd8npek18k6be8ba3oc68.apps.googleusercontent.com'
@@ -509,6 +509,9 @@ class InnerTube:
 
         self.use_po_token = use_po_token
         self.po_token_verifier = po_token_verifier or _default_po_token_verifier
+
+        if not self.allow_cache:
+            reset_cache()
 
         # Try to load from file if specified
         self.token_file = token_file or _token_file


### PR DESCRIPTION
### Notes

- Added the `reset_cache` function to `helpers.py` to delete the cache directory (`__cache__`).
- The function checks if the directory exists and removes it if so.
- This helps in clearing cached data when needed.

### Usage

#### When you think you should reset the cache, when using the use_oauth parameter, just import the function from helpers and call reset_cache()
```python
from pytubefix import YouTube
from pytubefix.cli import on_progress]
from pytubefix.helpers import reset_cache

reset_cache()
 
url = "url"

yt = YouTube(url, use_oauth=True, allow_oauth_cache=True, on_progress_callback = on_progress)
ys = yt.streams.get_highest_resolution()

ys.download()

```