### PR TITLE
Add STATUS and REASON to Exceptions error messages generated by UnknownVideoError

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
 VERSION=8
-MINOR=5
-PATCH=3
+MINOR=6
+PATCH=0
 EXTRAVERSION=""
 
-NOTES="(#358)"
+NOTES="(#359)"
 BRANCH="main"
 
 if [[ -z $PATCH ]]; then

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pytubefix"
-version = "8.5.3"
+version = "8.6.0"
 authors = [
   { name="Juan Bindez", email="juanbindez780@gmail.com" },
 ]

--- a/pytubefix/exceptions.py
+++ b/pytubefix/exceptions.py
@@ -309,4 +309,4 @@ class UnknownVideoError(VideoUnavailable):
 
     @property
     def error_string(self):
-        return f'{self.video_id} has an unknown error, check logs for more info'
+        return f'{self.video_id} has an unknown error, check logs for more info [Status: {self.status}] [Reason: {self.reason}]'

--- a/pytubefix/version.py
+++ b/pytubefix/version.py
@@ -1,4 +1,4 @@
-__version__ = "8.5.3"
+__version__ = "8.6.0"
 
 if __name__ == "__main__":
     print(__version__)


### PR DESCRIPTION
This PR add the "Status" and "Reason" to the Exception error messages returned by UnknownVideoError, as suggested at https://github.com/JuanBindez/pytubefix/issues/362#issuecomment-2501761232

By checking the keywords in that error message, the developer can decide how the code will move forward, if re-trying, give-up or something else.