### PR TITLE
Added method to get playlist thumbnail URL

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -2,46 +2,62 @@
 name: Bug Report
 about: Create a report to help us improve
 title: ''
-labels: bug
+labels: bug, enhancement
 assignees: ''
 
 ---
 
-**:exclamation:  DO NOT REMOVE OR SKIP THE ISSUE TEMPLATE :exclamation:**
+# 🛑 DO NOT REMOVE OR SKIP THIS ISSUE TEMPLATE 🛑  
+Issues with incomplete or missing information will be **closed automatically**.
 
-lack of information will lead to closure of the issue
+---
 
-__________
-**Describe the bug**
-A clear and concise description of what the bug is.
+## 🐞 **Bug Description**  
+Provide a clear and concise description of the bug.  
 
-__________
-**code that was used that resulted in the bug**
+---
+
+## 🔢 **Code Snippet**  
+Include the minimal code snippet that reproduces the issue.  
 
 ```python
 from pytubefix import YouTube
 
-# put your code here
-
+# Insert your code here
 ```
 
-__________
-**Expected behavior**
-A clear and concise description of what you expected to happen.
+---
 
+## 🎯 **Expected Behavior**  
+Describe what you expected to happen instead of the observed behavior.  
 
-__________
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
+---
 
+## 📸 **Screenshots or Logs**  
+If applicable, attach screenshots or logs that demonstrate the issue.  
+(Use a service like [Pastebin](https://pastebin.com/) if the logs are too lengthy.)  
 
-__________
-**Desktop (please complete the following information):**
- - OS: [Your Operating System and Version]
- - Python Version [x.y.z]
- - Pytubefix Version [x.y.z]
+---
 
+## 🖥️ **Environment Details**  
+Fill in the details below about your setup:  
+- **Operating System:** [e.g., Windows 10, macOS Monterey]  
+- **Python Version:** [e.g., 3.9.7]  
+- **Pytubefix Version:** [e.g., 1.2.3]  
 
-__________
-**Additional context**
-Add any other context about the problem here.
+---
+
+## 📋 **Additional Context**  
+Add any additional information or context that might help us resolve the issue.  
+
+---
+
+### ✅ **Checklist Before Submitting**  
+- [ ] I have read the [contribution guidelines](link_to_guidelines).  
+- [ ] I have verified that the issue exists in the latest version of the library.  
+- [ ] I have included all necessary details to reproduce the bug.  
+
+---
+
+### 🚀 **Next Steps**  
+Once submitted, we will triage the issue. Make sure to respond to follow-up questions to keep the process smooth.

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -53,7 +53,7 @@ Add any additional information or context that might help us resolve the issue.
 ---
 
 ### ✅ **Checklist Before Submitting**  
-- [ ] I have read the [contribution guidelines](link_to_guidelines).  
+- [ ] I have read the [contribution guidelines](https://github.com/JuanBindez/pytubefix/blob/main/Contributing.md).  
 - [ ] I have verified that the issue exists in the latest version of the library.  
 - [ ] I have included all necessary details to reproduce the bug.  
 

--- a/pytubefix/contrib/playlist.py
+++ b/pytubefix/contrib/playlist.py
@@ -405,6 +405,26 @@ class Playlist(Sequence):
             'title']['runs'][0]['text']
 
     @property
+    def thumbnail_url(self):
+        thumbnail_renderer = self.sidebar_info[0][
+                'playlistSidebarPrimaryInfoRenderer'][
+                'thumbnailRenderer']
+
+        if 'playlistVideoThumbnailRenderer' in thumbnail_renderer:
+            return thumbnail_renderer[
+                'playlistVideoThumbnailRenderer'][
+                'thumbnail'][
+                'thumbnails'][-1][
+                'url']
+
+        elif 'playlistCustomThumbnailRenderer' in thumbnail_renderer:
+            return thumbnail_renderer[
+                'playlistCustomThumbnailRenderer'][
+                'thumbnail'][
+                'thumbnails'][-1][
+                'url']
+
+    @property
     def description(self) -> str:
         return self.sidebar_info[0]['playlistSidebarPrimaryInfoRenderer'][
             'description']['simpleText']


### PR DESCRIPTION
## Added method to get playlist thumbnail URL #371 

YouTube provides thumbnails in two ways:

1. A custom thumbnail, provided by the author.

2. A standard thumbnail of the first video in the playlist (if the author does not define).

### This PR adds:

- `.thumbnail_url` method

### Usage example:

```python
p = Playlist('PLAYLIST_URL')

print(p.thumbnail_url)
```

