### PR TITLE
Fixed failure in extracting and interpreting sig and nsig in the player (3bb1f723)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,11 +2,11 @@
 
 VERSION=8
 MINOR=8
-PATCH=
-EXTRAVERSION="-rc1"
+PATCH=0
+EXTRAVERSION=""
 
 NOTES="(#372)"
-BRANCH="dev"
+BRANCH="main"
 
 if [[ -z $PATCH ]]; then
     PATCH=""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pytubefix"
-version = "8.8-rc1"
+version = "8.8.0"
 authors = [
   { name="Juan Bindez", email="juanbindez780@gmail.com" },
 ]

--- a/pytubefix/jsinterp.py
+++ b/pytubefix/jsinterp.py
@@ -430,6 +430,12 @@ class LocalNameSpace(collections.ChainMap):
         raise NotImplementedError('Deleting is not supported')
 
 
+def _fixup_n_function_code(argnames, code):
+    return argnames, re.sub(
+        rf';\s*if\s*\(\s*typeof\s+[a-zA-Z0-9_$]+\s*===?\s*(["\'])undefined\1\s*\)\s*return\s+{argnames[0]};',
+        ';', code)
+
+
 class JSInterpreter:
     __named_object_counter = 0
 
@@ -1069,7 +1075,7 @@ class JSInterpreter:
 
     def extract_function(self, funcname):
         return function_with_repr(
-            self.extract_function_from_code(*self.extract_function_code(funcname)),
+            self.extract_function_from_code(*_fixup_n_function_code(*self.extract_function_code(funcname))),
             f'F<{funcname}>')
 
     def extract_function_from_code(self, argnames, code, *global_stack):

--- a/pytubefix/version.py
+++ b/pytubefix/version.py
@@ -1,4 +1,4 @@
-__version__ = "8.8-rc1"
+__version__ = "8.8.0"
 
 if __name__ == "__main__":
     print(__version__)


### PR DESCRIPTION
## Fix for the player [3bb1f723](https://www.youtube.com/s/player/3bb1f723/player_ias.vflset/en_US/base.js) #375 

This player changed the structure of the sig and nsig functions, causing errors in all clients that need to resolve these parameters.

### Changes to this PR:

- Update the regex to find the resolution function of the `sig` and `n` parameter.

- Added a function in **jsinterp.py** to remove problematic redundant function from javascript.