### PR TITLE
Fix "TypeError: Exception does not take keyword arguments" in player [2f1832d2]

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -2,7 +2,7 @@
 name: Bug Report
 about: Create a report to help us improve
 title: ''
-labels: bug, enhancement
+labels: bug
 assignees: ''
 
 ---
@@ -21,8 +21,6 @@ Provide a clear and concise description of the bug.
 Include the minimal code snippet that reproduces the issue.  
 
 ```python
-from pytubefix import YouTube
-
 # Insert your code here
 ```
 
@@ -34,8 +32,6 @@ Describe what you expected to happen instead of the observed behavior.
 ---
 
 ## 📸 **Screenshots or Logs**  
-If applicable, attach screenshots or logs that demonstrate the issue.  
-(Use a service like [Pastebin](https://pastebin.com/) if the logs are too lengthy.)  
 
 ---
 
@@ -51,13 +47,5 @@ Fill in the details below about your setup:
 Add any additional information or context that might help us resolve the issue.  
 
 ---
-
-### ✅ **Checklist Before Submitting**  
-- [ ] I have read the [contribution guidelines](https://github.com/JuanBindez/pytubefix/blob/main/Contributing.md).  
-- [ ] I have verified that the issue exists in the latest version of the library.  
-- [ ] I have included all necessary details to reproduce the bug.  
-
----
-
 ### 🚀 **Next Steps**  
 Once submitted, we will triage the issue. Make sure to respond to follow-up questions to keep the process smooth.

--- a/pytubefix/cipher.py
+++ b/pytubefix/cipher.py
@@ -62,9 +62,9 @@ def get_initial_function_name(js: str, js_url: str) -> str:
     """
 
     function_patterns = [
-        r'(?P<sig>[a-zA-Z0-9$]+)\s*=\s*function\(\s*(?P<arg>[a-zA-Z0-9$]+)\s*\)\s*{\s*(?P=arg)\s*=\s*(?P=arg)\.split\(\s*""\s*\)\s*;\s*[^}]+;\s*return\s+(?P=arg)\.join\(\s*""\s*\)',
-        r'(?:\b|[^a-zA-Z0-9$])(?P<sig>[a-zA-Z0-9$]{2,})\s*=\s*function\(\s*a\s*\)\s*{\s*a\s*=\s*a\.split\(\s*""\s*\)(?:;[a-zA-Z0-9$]{2}\.[a-zA-Z0-9$]{2}\(a,\d+\))?',
-        r'\b(?P<var>[a-zA-Z0-9$]+)&&\((?P=var)=(?P<sig>[a-zA-Z0-9$]{2,})\(decodeURIComponent\((?P=var)\)\)',
+        r'(?P<sig>[a-zA-Z0-9_$]+)\s*=\s*function\(\s*(?P<arg>[a-zA-Z0-9_$]+)\s*\)\s*{\s*(?P=arg)\s*=\s*(?P=arg)\.split\(\s*""\s*\)\s*;\s*[^}]+;\s*return\s+(?P=arg)\.join\(\s*""\s*\)',
+        r'(?:\b|[^a-zA-Z0-9_$])(?P<sig>[a-zA-Z0-9_$]{2,})\s*=\s*function\(\s*a\s*\)\s*{\s*a\s*=\s*a\.split\(\s*""\s*\)(?:;[a-zA-Z0-9_$]{2}\.[a-zA-Z0-9_$]{2}\(a,\d+\))?',
+        r'\b(?P<var>[a-zA-Z0-9_$]+)&&\((?P=var)=(?P<sig>[a-zA-Z0-9_$]{2,})\(decodeURIComponent\((?P=var)\)\)',
         # Old patterns
         r'\b[cs]\s*&&\s*[adf]\.set\([^,]+\s*,\s*encodeURIComponent\s*\(\s*(?P<sig>[a-zA-Z0-9$]+)\(',
         r'\b[a-zA-Z0-9]+\s*&&\s*[a-zA-Z0-9]+\.set\([^,]+\s*,\s*encodeURIComponent\s*\(\s*(?P<sig>[a-zA-Z0-9$]+)\(',


### PR DESCRIPTION
### Fix "TypeError: Exception does not take keyword arguments" in player [2f1832d2](https://www.youtube.com/s/player/2f1832d2/player_ias.vflset/en_US/base.js).

Youtube has updated the `n` parameter extraction regex again