### PR TITLE
Fixed incorrect client when using potoken

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,10 +2,10 @@
 
 VERSION=8
 MINOR=8
-PATCH=1
+PATCH=2
 EXTRAVERSION=""
 
-NOTES="(#374)"
+NOTES="(#382)"
 BRANCH="main"
 
 if [[ -z $PATCH ]]; then

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pytubefix"
-version = "8.8.1"
+version = "8.8.2"
 authors = [
   { name="Juan Bindez", email="juanbindez780@gmail.com" },
 ]

--- a/pytubefix/__main__.py
+++ b/pytubefix/__main__.py
@@ -137,7 +137,7 @@ class YouTube:
         self.client = 'WEB' if use_po_token else client
 
         # oauth can only be used by the TV and TV_EMBED client.
-        self.client = 'TV' if use_oauth else client
+        self.client = 'TV' if use_oauth else self.client
 
         self.fallback_clients = ['MWEB', 'IOS', 'TV', 'WEB']
 

--- a/pytubefix/version.py
+++ b/pytubefix/version.py
@@ -1,4 +1,4 @@
-__version__ = "8.8.1"
+__version__ = "8.8.2"
 
 if __name__ == "__main__":
     print(__version__)


### PR DESCRIPTION
## Fixed error that did not change the client to WEB when using `use_po_token=True`

The PoToken generated by BotGuard was made to work on WEB clients and may generate errors if used with other clients.

This error did not change the client and used ANDROID_VR if the user did not provide it manually.

This PR fixes this issue and uses the WEB client when potoken is used.