### PR TITLE
Changed MWEB client UA to skip poToken

### DIFF
--- a/pytubefix/innertube.py
+++ b/pytubefix/innertube.py
@@ -133,12 +133,12 @@ _default_clients = {
             'context': {
                 'client': {
                     'clientName': 'MWEB',
-                    'clientVersion': '2.20240726.01.00'
+                    'clientVersion': '2.20241202.07.00'
                 }
             }
         },
         'header': {
-            'User-Agent': 'Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Mobile Safari/537.36',
+            'User-Agent': 'Mozilla/5.0 (iPad; CPU OS 16_7_10 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.6 Mobile/15E148 Safari/604.1,gzip(gfe)',
             'X-Youtube-Client-Name': '2'
         },
         'api_key': 'AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8',


### PR DESCRIPTION
## This is just a temporary fix and may stop working soon.

Recently, the MWEB client started to need poToken to obtain adaptive steams. But there seems to be a User-Agent capable of bypassing this.

I believe it's only a matter of time before YouTube fixes this, but it could be useful for now.