### PR TITLE
Improved fallback logic

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,10 +2,10 @@
 
 VERSION=8
 MINOR=10
-PATCH=0
+PATCH=1
 EXTRAVERSION=""
 
-NOTES="(#388)"
+NOTES="(#402)"
 BRANCH="main"
 
 if [[ -z $PATCH ]]; then

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pytubefix"
-version = "8.10.0"
+version = "8.10.1"
 authors = [
   { name="Juan Bindez", email="juanbindez780@gmail.com" },
 ]

--- a/pytubefix/exceptions.py
+++ b/pytubefix/exceptions.py
@@ -272,6 +272,21 @@ class AgeCheckRequiredAccountError(VideoUnavailable):
             f"some users. Sign in to your primary account to confirm your age.")
 
 
+class InnerTubeResponseError(VideoUnavailable):
+    def __init__(self, video_id: str, client: str):
+        """
+        :param str video_id:
+            A YouTube video identifier.
+        """
+        self.video_id = video_id
+        self.client = client
+        super().__init__(self.video_id)
+
+    @property
+    def error_string(self):
+        return (
+            f"{self.video_id} : {self.client} client did not receive a response from YouTube")
+
 ## 3. Unknown Error Type, Important to Developer ##
 
 

--- a/pytubefix/version.py
+++ b/pytubefix/version.py
@@ -1,4 +1,4 @@
-__version__ = "8.10.0"
+__version__ = "8.10.1"
 
 if __name__ == "__main__":
     print(__version__)


### PR DESCRIPTION
Fix https://github.com/JuanBindez/pytubefix/issues/400#issuecomment-2573291382

For some reason YouTube may also return `This video is not available` for some videos.

If no fallback client is able to obtain a valid response, a content check will be performed on `self._vid_info`. If nothing is sent, an `InnerTubeResponseError` will be thrown.