### PR TITLE
Optimized visitorData extraction

### DIFF
--- a/pytubefix/__main__.py
+++ b/pytubefix/__main__.py
@@ -232,11 +232,16 @@ class YouTube:
         if self._visitor_data:
             return self._visitor_data
 
-        innertube_response = InnerTube('WEB').player(self.video_id)
         try:
-            self._visitor_data = innertube_response['responseContext']['visitorData']
-        except KeyError:
-            self._visitor_data = innertube_response['responseContext']['serviceTrackingParams'][0]['params'][6]['value']
+            logger.debug("Looking for visitorData in initial_data")
+            self._visitor_data = extract.visitor_data(str(self.initial_data['responseContext']))
+        except (KeyError, pytubefix.exceptions.RegexMatchError):
+            logger.debug("Unable to obtain visitorData from initial_data. Trying to request from the WEB client")
+            innertube_response = InnerTube('WEB').player(self.video_id)
+            try:
+                self._visitor_data = innertube_response['responseContext']['visitorData']
+            except KeyError:
+                self._visitor_data = innertube_response['responseContext']['serviceTrackingParams'][0]['params'][6]['value']
         logger.debug('VisitorData obtained successfully')
 
         return self._visitor_data

--- a/pytubefix/extract.py
+++ b/pytubefix/extract.py
@@ -123,6 +123,10 @@ def signature_timestamp(js: str) -> str:
     return regex_search(r"signatureTimestamp:(\d*)", js, group=1)
 
 
+def visitor_data(response_context: str) -> str:
+    return regex_search(r"visitor_data[',\"\s]+value['\"]:\s?['\"]([a-zA-Z0-9_%-]+)['\"]", response_context, group=1)
+
+
 def video_id(url: str) -> str:
     """Extract the ``video_id`` from a YouTube url.
 
@@ -414,6 +418,7 @@ def apply_po_token(stream_manifest: Dict, vid_info: Dict, po_token: str) -> None
     :param str po_token:
         Proof of Origin Token.
     """
+    logger.debug(f'Applying poToken')
     for i, stream in enumerate(stream_manifest):
         try:
             url: str = stream["url"]
@@ -433,7 +438,6 @@ def apply_po_token(stream_manifest: Dict, vid_info: Dict, po_token: str) -> None
             k: v[0] for k, v in query_params.items()
         }
 
-        logger.debug(f'Applying po_token to itag={stream["itag"]}')
         query_params['pot'] = po_token
 
         url = f'{parsed_url.scheme}://{parsed_url.netloc}{parsed_url.path}?{urlencode(query_params)}'


### PR DESCRIPTION
## Optimized visitorData extraction

Now visitorData is obtained from the YouTube HTML initialData.

WEB-based clients need to download the HTML to get the base.js version, so now we will also get the visitorData and request it from the API only if the HTML extraction fails.

In particular, this improved the performance of pytubefix for poToken clients by 1 second.