### PR TITLE
Fixed bot detection on all clients 

### DIFF
--- a/pytubefix/innertube.py
+++ b/pytubefix/innertube.py
@@ -38,7 +38,7 @@ _default_clients = {
                     'clientName': 'WEB',
                     'osName': 'Windows',
                     'osVersion': '10.0',
-                    'clientVersion': '2.20240726.00.00',
+                    'clientVersion': '2.20250122.01.00',
                     'platform': 'DESKTOP'
                 }
             }
@@ -46,7 +46,7 @@ _default_clients = {
         'header': {
             'User-Agent': 'Mozilla/5.0',
             'X-Youtube-Client-Name': '1',
-            'X-Youtube-Client-Version': '2.20240726.00.00'
+            'X-Youtube-Client-Version': '2.20250122.01.00'
         },
         'api_key': 'AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8',
         'require_js_player': True,
@@ -143,7 +143,7 @@ _default_clients = {
         },
         'api_key': 'AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8',
         'require_js_player': True,
-        'require_po_token': False
+        'require_po_token': True
     },
 
     'WEB_KIDS': {
@@ -707,13 +707,19 @@ class InnerTube:
         self.expires = start_time + response_data['expires_in']
         self.cache_tokens()
 
+    def insert_visitor_data(self, visitor_data: str) -> None:
+        """
+        Insert visitorData in the API request
+        """
+        self.innertube_context['context']['client'].update({
+            "visitorData": visitor_data
+        })
+
     def insert_po_token(self, visitor_data:str=None, po_token:str=None) -> None:
         """
         Insert visitorData and po_token in the API request
         """
-        self.innertube_context['context']['client'].update({
-            "visitorData": self.access_visitorData or visitor_data
-        })
+        self.insert_visitor_data(self.access_visitorData or visitor_data)
 
         self.innertube_context.update({
             "serviceIntegrityDimensions": {


### PR DESCRIPTION
## Fixed bot detection on all clients #421

As discovered here [https://github.com/JuanBindez/pytubefix/issues/386#issuecomment-2576088902](https://github.com/JuanBindez/pytubefix/issues/386#issuecomment-2576088902) during A/B testing, YouTube now requires `visitorData` to be sent, otherwise a bot detection error is returned.

So now pytubefix will retrieve the visitorData and send it in the API request.

**This does not resolve bot detection issues when the IP is already blocked.**

### Changes

- inserted visitorData for all clients

- Retrieved visitorData from html for poToken clients, and from API response for non-poToken clients (this improves performance)

- `MWEB` client now requires poToken to obtain functional streams

- This PR also fixes: #420

