### PR TITLE
Fixed "KeyError: 'throw'"

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -7,7 +7,7 @@ MINOR=12
 PATCH=2
 EXTRAVERSION=""
 NOTES="(#438 #442)"
-BRANCH="dev"
+BRANCH="main"
 
 if [[ -z $PATCH ]]; then
     PATCH=""

--- a/pytubefix/cipher.py
+++ b/pytubefix/cipher.py
@@ -62,7 +62,7 @@ def get_initial_function_name(js: str, js_url: str) -> str:
     """
 
     function_patterns = [
-        r'(?P<sig>[a-zA-Z0-9_$]+)\s*=\s*function\(\s*(?P<arg>[a-zA-Z0-9_$]+)\s*\)\s*{\s*(?P=arg)\s*=\s*(?P=arg)\.split\(\s*""\s*\)\s*;\s*[^}]+;\s*return\s+(?P=arg)\.join\(\s*""\s*\)',
+        r'(?P<sig>[a-zA-Z0-9_$]+)\s*=\s*function\(\s*(?P<arg>[a-zA-Z0-9_$]+)\s*\)\s*{\s*(?P=arg)\s*=\s*(?P=arg)\.split\(\s*[a-zA-Z0-9_\$\"\[\]]+\s*\)\s*;\s*[^}]+;\s*return\s+(?P=arg)\.join\(\s*[a-zA-Z0-9_\$\"\[\]]+\s*\)',
         r'(?:\b|[^a-zA-Z0-9_$])(?P<sig>[a-zA-Z0-9_$]{2,})\s*=\s*function\(\s*a\s*\)\s*{\s*a\s*=\s*a\.split\(\s*""\s*\)(?:;[a-zA-Z0-9_$]{2}\.[a-zA-Z0-9_$]{2}\(a,\d+\))?',
         r'\b(?P<var>[a-zA-Z0-9_$]+)&&\((?P=var)=(?P<sig>[a-zA-Z0-9_$]{2,})\(decodeURIComponent\((?P=var)\)\)',
         # Old patterns


### PR DESCRIPTION
## Fixed `"KeyError: 'throw'"` #451 #450 #444 

YouTube has changed its base.js obfuscation algorithm.

Now the `sig` and `nsig` deobfuscation functions require an array instantiated globally, usually at the beginning of the file.

The `KeyError` of the javascript interpreter is due to the fact that it only takes the function necessary for deobfuscation.

### Changes:

- Changed the regex to get the `sig` function.

- Now **jsinterp** looks for the global array when called and adds it to the local function.

- Added support for javascript `typeof` interpretation.

- Added function to get global variables (usually used in nsig's typeof).