### PR TITLE
Fixed RegexMatchError: get_throttling_function_name in player 753b1819

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -4,9 +4,9 @@ set -e
 
 VERSION=8
 MINOR=12
-PATCH=2
+PATCH=3
 EXTRAVERSION=""
-NOTES="(#438 #442)"
+NOTES="(#452)"
 BRANCH="main"
 
 if [[ -z $PATCH ]]; then

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pytubefix"
-version = "8.12.2"
+version = "8.12.3"
 authors = [
   { name="Juan Bindez", email="juanbindez780@gmail.com" },
 ]

--- a/pytubefix/exceptions.py
+++ b/pytubefix/exceptions.py
@@ -44,6 +44,15 @@ class RegexMatchError(ExtractError):
         self.pattern = pattern
 
 
+class InterpretationError(PytubeFixError):
+    def __init__(self, js_url: str):
+        self.js_url = js_url
+        super().__init__(self.error_string)
+
+    @property
+    def error_string(self):
+        return f'Error interpreting player js: {self.js_url}'
+
 ### Video Unavailable Errors ###
 # There are really 3 types of errors thrown
 # 1. VideoUnavailable - This is the base error type for all video errors. 

--- a/pytubefix/extract.py
+++ b/pytubefix/extract.py
@@ -323,6 +323,7 @@ def get_ytplayer_js(html: str) -> Any:
         if function_match:
             logger.debug("finished regex search, matched: %s", pattern)
             yt_player_js = function_match.group(1)
+            logger.debug("player JS: " + yt_player_js)
             return yt_player_js
 
     raise RegexMatchError(

--- a/pytubefix/version.py
+++ b/pytubefix/version.py
@@ -1,4 +1,4 @@
-__version__ = "8.12.2"
+__version__ = "8.12.3"
 
 if __name__ == "__main__":
     print(__version__)


### PR DESCRIPTION
## More robust nsig name extraction #464 [https://github.com/JuanBindez/pytubefix/issues/444#issuecomment-2815591633](https://github.com/JuanBindez/pytubefix/issues/444#issuecomment-2815591633)

This PR changes the way to get the name of the nsig function. 

Recently YouTube has been using the global object in several functions, obfuscating the code. So now pytubefix will try to get the name of the nsig function based on the global object.

### How it works

The global object, after being interpreted, has an index that contains a string, usually starting with perhaps a cipher and ending with `_w8_`. This string is returned by the nsig function along with the parameter `n` if the interpretation fails.

So now pytubefix will retrieve and interpret the global object, it will look for the index of the `_w8_` parameter so the regex can find the function correctly. And if this new extraction method fails, pytubefix will try the old method.

### Change

* Improved nsig function name extraction, based on [https://github.com/yt-dlp/yt-dlp/pull/12761](https://github.com/yt-dlp/yt-dlp/pull/12761)

* Added `InterpretationError` exception to jsinterp for better error tracking

* Added the player version to the debug logger to make maintenance easier in the project