### PR TITLE
Languages in audio tracks are not regionalized 

### DIFF
--- a/pytubefix/streams.py
+++ b/pytubefix/streams.py
@@ -100,9 +100,13 @@ class Stream:
         if self.includes_multiple_audio_tracks:
             self.is_default_audio_track = stream['audioTrack']['audioIsDefault']
             self.audio_track_name = str(stream['audioTrack']['displayName']).split(" ")[0]
+            self.audio_track_name_full = str(stream['audioTrack']['displayName'])
+            self.audio_track_language_id= str(stream['audioTrack']['id']).split(".")[0]
         else:
             self.is_default_audio_track = self.includes_audio_track and not self.includes_video_track
             self.audio_track_name = None
+            self.audio_track_name_full = None
+            self.audio_track_language_id= None
 
     @property
     def is_adaptive(self) -> bool:

--- a/pytubefix/streams.py
+++ b/pytubefix/streams.py
@@ -99,13 +99,15 @@ class Stream:
         self.includes_multiple_audio_tracks: bool = 'audioTrack' in stream
         if self.includes_multiple_audio_tracks:
             self.is_default_audio_track = stream['audioTrack']['audioIsDefault']
-            self.audio_track_name = str(stream['audioTrack']['displayName']).split(" ")[0]
-            self.audio_track_name_full = str(stream['audioTrack']['displayName'])
-            self.audio_track_language_id= str(stream['audioTrack']['id']).split(".")[0]
+            self.audio_track_name_regionalized = str(stream['audioTrack']['displayName']).replace(" original", "")
+            self.audio_track_name = self.audio_track_name_regionalized.split(" ")[0]
+            self.audio_track_language_id_regionalized= str(stream['audioTrack']['id']).split(".")[0]
+            self.audio_track_language_id= self.audio_track_language_id_regionalized.split("-")[0] 
         else:
             self.is_default_audio_track = self.includes_audio_track and not self.includes_video_track
+            self.audio_track_name_regionalized = None
             self.audio_track_name = None
-            self.audio_track_name_full = None
+            self.audio_track_language_id_regionalized = None
             self.audio_track_language_id= None
 
     @property


### PR DESCRIPTION
### Languages in audio tracks are not regionalized  #462 
This PR includes the full names in audio tracks (as YouTube gives them) aswell as their language codes, so people can choose regionalized language when downloading the audio as Spanish (Latin-America), Chinese (simplified) etc. 

## Changes 
- Added variable to stream: audio_track_name_regionalized-> gives the full audio track name ex. Spanish (Latin-America), Dutch (Netherlands) etc as they're shown in Youtube, the original has been trimmed since we have a bool to check for this. 
- Added variable to stream: audio_track_language_id -> gives the base language id for the stream ex fr -> French, es -> Spanish etc. 
- Added variable to stream: audio_track_language_id_regionalized -> gives the full language code for the stream ex. French (France) -> Fr-fr, Spanish (Latin-America) -> es-419 etc

