### PR TITLE
fixed pytubefix.Playlist().video_urls fail for long playlists

### DIFF
--- a/pytubefix/contrib/playlist.py
+++ b/pytubefix/contrib/playlist.py
@@ -251,9 +251,13 @@ class Playlist(Sequence):
         try:
             # For some reason YouTube only returns the first 100 shorts of a playlist
             # token provided by the API doesn't seem to work even in the official player
-            continuation = videos[-1]['continuationItemRenderer'][
-                'continuationEndpoint'
-            ]['continuationCommand']['token']
+            try:
+                continuation = videos[-1]['continuationItemRenderer']['continuationEndpoint']['continuationCommand']['token']
+            except:
+                for command in videos[-1]['continuationItemRenderer']['continuationEndpoint']['commandExecutorCommand']['commands']:
+                    if 'continuationCommand' in command:
+                        continuation = command['continuationCommand']['token']
+                        break
             videos = videos[:-1]
         except (KeyError, IndexError):
             # if there is an error, no continuation is available


### PR DESCRIPTION
Fixed the issue causing pytubefix.Playlist().video_urls to return an invalid result for playlists with more than 100 videos, as outlined in issue #455