### PR TITLE
Creates "Channel.lives" as an alias for "Channel.live"

### DIFF
--- a/pytubefix/contrib/channel.py
+++ b/pytubefix/contrib/channel.py
@@ -630,6 +630,11 @@ class Channel(Playlist):
         return DeferredGeneratorList(self.videos_generator())
 
     @property
+    def lives(self) -> Iterable[YouTube]:
+        """Alias for the 'live' property."""
+        return self.live
+
+    @property
     def releases(self) -> Iterable[Playlist]:
         """Yields Playlist objects in this channel
 


### PR DESCRIPTION
The `Channel` object allows calling `videos` and `shorts` (plural), as well as `live` (singular), among other properties. This naming follows YouTube's tab structure but can sometimes lead to confusion, including for AI-based code generators, as it is common to expect the property to be called `lives` (plural).

To address this, an alias for the `live` property has been created, allowing it to also be called as `lives`. The alias does not affect existing or future code because `live` continues to work as usual.


Example of usage:
```
from pytubefix import Channel

channel_id = "UCzQUP1qoWDoEbmsQxvdjxgQ"

channel_url = f"https://www.youtube.com/channel/{channel_id}"
ch = Channel(channel_url) 

print("First 10 live video IDs:")
counter = 0
for l in ch.lives:
    print(l.video_id)
    counter += 1
    if counter == 10:
        break
```