### PR TITLE
Update Node binary detection for macOS compatibility

### DIFF
--- a/pytubefix/botGuard/bot_guard.py
+++ b/pytubefix/botGuard/bot_guard.py
@@ -4,7 +4,7 @@ import sys
 
 PLATFORM = sys.platform
 
-NODE = 'node' if PLATFORM == 'linux' else 'node.exe'
+NODE = 'node' if PLATFORM in ['linux', 'darwin'] else 'node.exe'
 
 NODE_PATH = os.path.dirname(os.path.realpath(__file__)) + f'/binaries/{NODE}'
 


### PR DESCRIPTION
Modified the platform check to include 'darwin', ensuring the correct Node binary is used on macOS. 

This fixes compatibility issues when running on macOS systems.