### PR TITLE
SABR implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ coverage.xml
 *.mp4
 *.mp3
 *.webm
+*.m4a
 
 # Performance profiling
 prof/

--- a/build.sh
+++ b/build.sh
@@ -4,9 +4,9 @@ set -e
 
 VERSION=9
 MINOR=0
-PATCH=0
+PATCH=1
 EXTRAVERSION=""
-NOTES="(#469 #479 #481 #482)"
+NOTES="(fix #486 -> to check)"
 BRANCH="main"
 
 if [[ -z $PATCH ]]; then

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pytubefix"
-version = "9.0.0"
+version = "9.0.1"
 authors = [
   { name="Juan Bindez", email="juanbindez780@gmail.com" },
 ]

--- a/pytubefix/__main__.py
+++ b/pytubefix/__main__.py
@@ -347,6 +347,8 @@ class YouTube:
             video = Stream(
                 stream=stream,
                 monostate=self.stream_monostate,
+                po_token=self.po_token,
+                video_playback_ustreamer_config=self.video_playback_ustreamer_config
             )
             self._fmt_streams.append(video)
 
@@ -448,6 +450,14 @@ class YouTube:
                 }
             }
         return self._signature_timestamp
+
+    @property
+    def video_playback_ustreamer_config(self):
+        return self.vid_info[
+            'playerConfig'][
+            'mediaCommonConfig'][
+            'mediaUstreamerRequestConfig'][
+            'videoPlaybackUstreamerConfig']
 
     @property
     def vid_info(self):

--- a/pytubefix/__main__.py
+++ b/pytubefix/__main__.py
@@ -148,7 +148,7 @@ class YouTube:
 
         # Shared between all instances of `Stream` (Borg pattern).
         self.stream_monostate = Monostate(
-            on_progress=on_progress_callback, on_complete=on_complete_callback
+            on_progress=on_progress_callback, on_complete=on_complete_callback, youtube=self
         )
 
         if proxies:
@@ -458,6 +458,21 @@ class YouTube:
             'mediaCommonConfig'][
             'mediaUstreamerRequestConfig'][
             'videoPlaybackUstreamerConfig']
+
+    @property
+    def server_abr_streaming_url(self):
+        """
+        Extract the url for abr server and decrypt the `n` parameter
+        """
+        try:
+            url = self.vid_info[
+                'streamingData'][
+                'serverAbrStreamingUrl']
+            stream_manifest = [{"url": url}]
+            extract.apply_signature(stream_manifest, vid_info=self.vid_info, js=self.js, url_js=self.js_url)
+            return stream_manifest[0]["url"]
+        except Exception:
+            return None
 
     @property
     def vid_info(self):

--- a/pytubefix/__main__.py
+++ b/pytubefix/__main__.py
@@ -265,8 +265,8 @@ class YouTube:
         try:
             self._pot = bot_guard.generate_po_token(visitor_data=self.visitor_data)
             logger.debug('PoToken generated successfully')
-        except (FileNotFoundError, CalledProcessError):
-            logger.warning('Unable to run botGuard. Skipping poToken generation')
+        except Exception as e:
+            logger.warning('Unable to run botGuard. Skipping poToken generation, reason: ' + e.__str__())
         return self._pot
 
     @property

--- a/pytubefix/exceptions.py
+++ b/pytubefix/exceptions.py
@@ -25,6 +25,14 @@ class HTMLParseError(PytubeFixError):
 class ExtractError(PytubeFixError):
     """Data extraction based exception."""
 
+class Sabr(PytubeFixError):
+    def __init__(self, msg: str):
+        self.msg = msg
+        super().__init__(self.msg)
+
+    @property
+    def error_string(self):
+        return self.msg
 
 class RegexMatchError(ExtractError):
     """Regex pattern did not return any matches."""

--- a/pytubefix/exceptions.py
+++ b/pytubefix/exceptions.py
@@ -25,7 +25,7 @@ class HTMLParseError(PytubeFixError):
 class ExtractError(PytubeFixError):
     """Data extraction based exception."""
 
-class Sabr(PytubeFixError):
+class SABRError(PytubeFixError):
     def __init__(self, msg: str):
         self.msg = msg
         super().__init__(self.msg)

--- a/pytubefix/extract.py
+++ b/pytubefix/extract.py
@@ -552,6 +552,10 @@ def apply_descrambler(stream_data: Dict) -> Optional[List[Dict]]:
             cipher_url = parse_qs(data['signatureCipher'])
             data['url'] = cipher_url['url'][0]
             data['s'] = cipher_url['s'][0]
+            data['is_sabr'] = False
+        elif 'url' not in data and 'signatureCipher' not in data:
+            data['url'] = stream_data['serverAbrStreamingUrl']
+            data['is_sabr'] = True
         data['is_otf'] = data.get('type') == 'FORMAT_STREAM_TYPE_OTF'
 
     logger.debug("applying descrambler")

--- a/pytubefix/innertube.py
+++ b/pytubefix/innertube.py
@@ -38,7 +38,7 @@ _default_clients = {
                     'clientName': 'WEB',
                     'osName': 'Windows',
                     'osVersion': '10.0',
-                    'clientVersion': '2.20250122.01.00',
+                    'clientVersion': '2.20250523.01.00',
                     'platform': 'DESKTOP'
                 }
             }
@@ -46,7 +46,7 @@ _default_clients = {
         'header': {
             'User-Agent': 'Mozilla/5.0',
             'X-Youtube-Client-Name': '1',
-            'X-Youtube-Client-Version': '2.20250122.01.00'
+            'X-Youtube-Client-Version': '2.20250523.01.00'
         },
         'api_key': 'AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8',
         'require_js_player': True,

--- a/pytubefix/monostate.py
+++ b/pytubefix/monostate.py
@@ -6,9 +6,11 @@ class Monostate:
                 on_progress: Optional[Callable[[Any, bytes, int], None]],
                 on_complete: Optional[Callable[[Any, Optional[str]], None]],
                 title: Optional[str] = None,
-                duration: Optional[int] = None,):
+                duration: Optional[int] = None,
+                youtube = None):
         
         self.on_progress = on_progress
         self.on_complete = on_complete
         self.title = title
         self.duration = duration
+        self.youtube = youtube

--- a/pytubefix/query.py
+++ b/pytubefix/query.py
@@ -255,9 +255,9 @@ class StreamQuery(Sequence):
 
         """
         if isinstance(itag, int):
-            return self.itag_index.get(itag)
+            return self._filter([lambda s: not s.unprocessed_audio]).itag_index.get(itag)
         elif isinstance(itag, str) and itag.isdigit():
-            return self.itag_index.get(int(itag))
+            return self._filter([lambda s: not s.unprocessed_audio]).itag_index.get(int(itag))
 
     def get_by_resolution(self, resolution: str) -> Optional[Stream]:
         """Get the corresponding :class:`Stream <Stream>` for a given resolution.

--- a/pytubefix/query.py
+++ b/pytubefix/query.py
@@ -36,6 +36,7 @@ class StreamQuery(Sequence):
         progressive=None,
         adaptive=None,
         is_dash=None,
+        is_drc=None,
         audio_track_name=None,
         custom_filter_functions=None,
     ):
@@ -115,6 +116,9 @@ class StreamQuery(Sequence):
         :param bool only_video:
             Excludes streams with audio tracks.
 
+        :param bool is_drc:
+            Include/exclude stable volume streams.
+
         :param audio_track_name:
             Name of the dubbed audio track
         :type type:
@@ -183,6 +187,9 @@ class StreamQuery(Sequence):
 
         if is_dash is not None:
             filters.append(lambda s: s.is_dash == is_dash)
+
+        if is_drc is not None:
+            filters.append(lambda s: s.is_drc == is_drc)
 
         return self._filter(filters)
 
@@ -255,9 +262,9 @@ class StreamQuery(Sequence):
 
         """
         if isinstance(itag, int):
-            return self._filter([lambda s: not s.unprocessed_audio]).itag_index.get(itag)
+            return self.itag_index.get(itag)
         elif isinstance(itag, str) and itag.isdigit():
-            return self._filter([lambda s: not s.unprocessed_audio]).itag_index.get(int(itag))
+            return self.itag_index.get(int(itag))
 
     def get_by_resolution(self, resolution: str) -> Optional[Stream]:
         """Get the corresponding :class:`Stream <Stream>` for a given resolution.

--- a/pytubefix/sabr/common.py
+++ b/pytubefix/sabr/common.py
@@ -35,6 +35,7 @@ class FormatId:
         while reader.pos < end:
             tag = reader.uint32()
             field_no = tag >> 3
+
             if field_no == 1 and tag == 8:
                 message["itag"] = reader.int32()
                 continue

--- a/pytubefix/sabr/common.py
+++ b/pytubefix/sabr/common.py
@@ -1,0 +1,122 @@
+# All credits to https://github.com/LuanRT/googlevideo
+
+from pytubefix.sabr.proto import BinaryWriter, BinaryReader
+
+
+def create_base_format_id():
+    return {
+        "itag": 0,
+        "lastModified": 0,
+        "xtags": None
+    }
+
+class FormatId:
+    @staticmethod
+    def encode(message: dict, writer=None):
+        if writer is None:
+            writer = BinaryWriter()
+
+        if message.get("itag", 0) != 0:
+            writer.uint32(8).int32(message["itag"])
+
+        if message.get("lastModified", 0) != 0:
+            writer.uint32(16).uint64(message["lastModified"])
+
+        if message.get("xtags", None) is not None:
+            writer.uint32(26).string(message["xtags"])
+
+        return writer
+
+    @staticmethod
+    def decode(input_data, length=None):
+        reader = input_data if isinstance(input_data, BinaryReader) else BinaryReader(input_data)
+        end = reader.len if length is None else reader.pos + length
+        message = create_base_format_id()
+        while reader.pos < end:
+            tag = reader.uint32()
+            field_no = tag >> 3
+            if field_no == 1 and tag == 8:
+                message["itag"] = reader.int32()
+                continue
+            elif field_no == 2 and tag == 16:
+                message["lastModified"] = reader.uint64()
+                continue
+            elif field_no == 3 and tag == 26:
+                message["xtags"] = reader.string()
+                continue
+            if (tag & 7) == 4 or tag == 0:
+                break
+            reader.skip(tag & 7)
+        return message
+
+class InitRange:
+    def __init__(self, start=0, end=0):
+        self.start = start
+        self.end = end
+
+    @staticmethod
+    def encode(message, writer=None):
+        if writer is None:
+            writer = BinaryWriter()
+        if message.start != 0:
+            writer.uint32(8)
+            writer.int32(message.start)
+        if message.end != 0:
+            writer.uint32(16)
+            writer.int32(message.end)
+        return writer
+
+    @staticmethod
+    def decode(input_data, length=None):
+        reader = input_data if isinstance(input_data, BinaryReader) else BinaryReader(input_data)
+        end = reader.len if length is None else reader.pos + length
+        message = InitRange()
+        while reader.pos < end:
+            tag = reader.uint32()
+            field_no = tag >> 3
+            if field_no == 1 and tag == 8:
+                message.start = reader.int32()
+                continue
+            elif field_no == 2 and tag == 16:
+                message.end = reader.int32()
+                continue
+            if (tag & 7) == 4 or tag == 0:
+                break
+            reader.skip(tag & 7)
+        return message
+
+class IndexRange:
+    @staticmethod
+    def encode(message: dict, writer=None):
+        if writer is None:
+            writer = BinaryWriter()
+
+        if message.get("start", 0) != 0:
+            writer.uint32(8).int32(message["start"])
+
+        if message.get("end", 0) != 0:
+            writer.uint32(16).int32(message["end"])
+
+        return writer
+
+    @staticmethod
+    def decode(input_data, length=None):
+        reader = input_data if isinstance(input_data, BinaryReader) else BinaryReader(input_data)
+        end = reader.len if length is None else reader.pos + length
+        message = {
+            "start": 0,
+            "end": 0
+        }
+        while reader.pos < end:
+            tag = reader.uint32()
+            field_no = tag >> 3
+            if field_no == 1 and tag == 8:
+                message["start"] = reader.int32()
+                continue
+            elif field_no == 2 and tag == 16:
+                message["end"] = reader.int32()
+                continue
+            if (tag & 7) == 4 or tag == 0:
+                break
+            reader.skip(tag & 7)
+        return message

--- a/pytubefix/sabr/core/UMP.py
+++ b/pytubefix/sabr/core/UMP.py
@@ -1,0 +1,135 @@
+# All credits to https://github.com/LuanRT/googlevideo
+
+class UMP:
+    def __init__(self, chunked_data_buffer):
+        """
+       Creates a new UMP parser.
+        :param chunked_data_buffer: Instance of a buffer containing data in UMP format.
+        """
+        self.chunked_data_buffer = chunked_data_buffer
+
+    def parse(self, handle_part):
+        """
+       Parses parts of the buffer and calls the handler for each complete part.
+        :param handle_part: Function called with each part complete.
+        :return: Partial if parsing is incomplete, otherwise None.
+        """
+        while True:
+            offset = 0
+            part_type, new_offset = self.read_varint(offset)
+            offset = new_offset
+            part_size, final_offset = self.read_varint(offset)
+            offset = final_offset
+
+            if part_type < 0 or part_size < 0:
+                break
+
+            if not self.chunked_data_buffer.can_read_bytes(offset, part_size):
+                if not self.chunked_data_buffer.can_read_bytes(offset, 1):
+                    break
+                return {
+                    "type": part_type,
+                    "size": part_size,
+                    "data": self.chunked_data_buffer
+                }
+
+            split_result = self.chunked_data_buffer.split(offset)['remaining_buffer'].split(part_size)
+            offset = 0
+            handle_part({
+                "type": part_type,
+                "size": part_size,
+                "data": split_result['extracted_buffer']
+            })
+            self.chunked_data_buffer = split_result['remaining_buffer']
+
+    def read_varint(self, offset):
+        """
+        Reads a variable length integer from the buffer.
+        :param offset: Initial reading position.
+        :return: Tuple (value, new offset), or (-1, offset) if incomplete.
+        """
+        if self.chunked_data_buffer.can_read_bytes(offset, 1):
+            first_byte = self.chunked_data_buffer.get_uint8(offset)
+            if first_byte < 128:
+                byte_length = 1
+            elif first_byte < 192:
+                byte_length = 2
+            elif first_byte < 224:
+                byte_length = 3
+            elif first_byte < 240:
+                byte_length = 4
+            else:
+                byte_length = 5
+        else:
+            byte_length = 0
+
+        if byte_length < 1 or not self.chunked_data_buffer.can_read_bytes(offset, byte_length):
+            return -1, offset
+
+        if byte_length == 1:
+            value = self.chunked_data_buffer.get_uint8(offset)
+            offset += 1
+        elif byte_length == 2:
+            byte1 = self.chunked_data_buffer.get_uint8(offset)
+            byte2 = self.chunked_data_buffer.get_uint8(offset + 1)
+            value = (byte1 & 0x3F) + 64 * byte2
+            offset += 2
+        elif byte_length == 3:
+            byte1 = self.chunked_data_buffer.get_uint8(offset)
+            byte2 = self.chunked_data_buffer.get_uint8(offset + 1)
+            byte3 = self.chunked_data_buffer.get_uint8(offset + 2)
+            value = (byte1 & 0x1F) + 32 * (byte2 + 256 * byte3)
+            offset += 3
+        elif byte_length == 4:
+            byte1 = self.chunked_data_buffer.get_uint8(offset)
+            byte2 = self.chunked_data_buffer.get_uint8(offset + 1)
+            byte3 = self.chunked_data_buffer.get_uint8(offset + 2)
+            byte4 = self.chunked_data_buffer.get_uint8(offset + 3)
+            value = (byte1 & 0x0F) + 16 * (byte2 + 256 * (byte3 + 256 * byte4))
+            offset += 4
+        else:
+            temp_offset = offset + 1
+            self.chunked_data_buffer.focus(temp_offset)
+
+            if self.can_read_from_current_chunk(temp_offset, 4):
+                view = self.get_current_data_view()
+                offset_in_chunk = temp_offset - self.chunked_data_buffer.current_chunk_offset
+                value = int.from_bytes(
+                    view[offset_in_chunk:offset_in_chunk + 4],
+                    byteorder='little'
+                )
+            else:
+                byte3 = (
+                    self.chunked_data_buffer.get_uint8(temp_offset + 2) +
+                    256 * self.chunked_data_buffer.get_uint8(temp_offset + 3)
+                )
+                value = (
+                    self.chunked_data_buffer.get_uint8(temp_offset) +
+                    256 * (
+                        self.chunked_data_buffer.get_uint8(temp_offset + 1) +
+                        256 * byte3
+                    )
+                )
+            offset += 5
+
+        return value, offset
+
+    def can_read_from_current_chunk(self, offset, length):
+        """
+        Checks whether the specified number of bytes can be read from the current chunk.
+        """
+        index = self.chunked_data_buffer.current_chunk_index
+        current_chunk = self.chunked_data_buffer.chunks[index]
+        return (
+            offset - self.chunked_data_buffer.current_chunk_offset + length
+            <= len(current_chunk)
+        )
+
+    def get_current_data_view(self):
+        """
+        Gets a binary view (DataView) of the current chunk.
+        """
+        if self.chunked_data_buffer.current_data_view is None:
+            chunk = self.chunked_data_buffer.chunks[self.chunked_data_buffer.current_chunk_index]
+            self.chunked_data_buffer.current_data_view = memoryview(chunk)
+        return self.chunked_data_buffer.current_data_view

--- a/pytubefix/sabr/core/chunked_data_buffer.py
+++ b/pytubefix/sabr/core/chunked_data_buffer.py
@@ -1,0 +1,113 @@
+# All credits to https://github.com/LuanRT/googlevideo
+
+class ChunkedDataBuffer:
+    def __init__(self, chunks=None):
+        """
+        Initializes a new ChunkedDataBuffer with the given chunks.
+        """
+        self.chunks = []
+        self.current_chunk_index = 0
+        self.current_chunk_offset = 0
+        self.current_data_view = None
+        self.total_length = 0
+
+        chunks = chunks or []
+        for chunk in chunks:
+            self.append(chunk)
+
+    def get_length(self):
+        return self.total_length
+
+    def append(self, chunk):
+        """
+        Adds a new chunk to the buffer, merging with the previous one if possible.
+        """
+        if self.can_merge_with_last_chunk(chunk):
+            last_chunk = self.chunks[-1]
+            merged = bytearray(last_chunk)
+            merged.extend(chunk)
+            self.chunks[-1] = bytes(merged)
+            self.reset_focus()
+        else:
+            self.chunks.append(chunk)
+        self.total_length += len(chunk)
+
+    def split(self, position):
+        """
+        Split the buffer at the specified position into two: extracted and remainder.
+        """
+        extracted_buffer = ChunkedDataBuffer()
+        remaining_buffer = ChunkedDataBuffer()
+        remaining_pos = position
+
+        for chunk in self.chunks:
+            chunk_len = len(chunk)
+            if remaining_pos >= chunk_len:
+                extracted_buffer.append(chunk)
+                remaining_pos -= chunk_len
+            elif remaining_pos > 0:
+                extracted_buffer.append(chunk[:remaining_pos])
+                remaining_buffer.append(chunk[remaining_pos:])
+                remaining_pos = 0
+            else:
+                remaining_buffer.append(chunk)
+
+        return {
+            "extracted_buffer": extracted_buffer,
+            "remaining_buffer": remaining_buffer
+        }
+
+    def is_focused(self, position):
+        """
+        Checks if the position is within the currently focused chunk.
+        """
+        chunk = self.chunks[self.current_chunk_index]
+        return self.current_chunk_offset <= position < self.current_chunk_offset + len(chunk)
+
+    def focus(self, position):
+        """
+        Moves the internal focus to the chunk containing the specified position.
+        """
+        if not self.is_focused(position):
+            if position < self.current_chunk_offset:
+                self.reset_focus()
+            while (self.current_chunk_offset + len(self.chunks[self.current_chunk_index]) <= position and
+                   self.current_chunk_index < len(self.chunks) - 1):
+                self.current_chunk_offset += len(self.chunks[self.current_chunk_index])
+                self.current_chunk_index += 1
+            self.current_data_view = None
+
+    def can_read_bytes(self, position, length):
+        """
+        Checks whether `length` bytes can be read from `position`.
+        """
+        return position + length <= self.total_length
+
+    def get_uint8(self, position):
+        """
+        Returns a single byte (as int) from the specified position.
+        """
+        self.focus(position)
+        chunk = self.chunks[self.current_chunk_index]
+        return chunk[position - self.current_chunk_offset]
+
+    def can_merge_with_last_chunk(self, chunk):
+        """
+        Checks if the new chunk can be merged with the last one.
+        """
+        if not self.chunks:
+            return False
+        last_chunk = self.chunks[-1]
+        return (
+            last_chunk is not None and
+            isinstance(last_chunk, (bytes, bytearray)) and
+            isinstance(chunk, (bytes, bytearray))
+        )
+
+    def reset_focus(self):
+        """
+        Resets focus to the beginning of the buffer.
+        """
+        self.current_data_view = None
+        self.current_chunk_index = 0
+        self.current_chunk_offset = 0

--- a/pytubefix/sabr/core/server_abr_stream.py
+++ b/pytubefix/sabr/core/server_abr_stream.py
@@ -1,0 +1,328 @@
+# All credits to https://github.com/LuanRT/googlevideo
+
+import base64
+from enum import Enum
+from typing import Optional
+from collections.abc import Callable
+from urllib.request import Request, urlopen
+
+from pytubefix.exceptions import Sabr
+from pytubefix.sabr.core.UMP import UMP
+from pytubefix.sabr.video_streaming.sabr_error import SabrError
+from pytubefix.sabr.video_streaming.media_header import MediaHeader
+from pytubefix.sabr.core.chunked_data_buffer import ChunkedDataBuffer
+from pytubefix.sabr.video_streaming.sabr_redirect import SabrRedirect
+from pytubefix.sabr.video_streaming.playback_cookie import PlaybackCookie
+from pytubefix.sabr.video_streaming.next_request_policy import NextRequestPolicy
+from pytubefix.sabr.video_streaming.stream_protection_status import StreamProtectionStatus
+from pytubefix.sabr.video_streaming.video_playback_abr_request import VideoPlaybackAbrRequest
+from pytubefix.sabr.video_streaming.format_initialization_metadata import FormatInitializationMetadata
+
+
+# https://github.com/gsuberland/UMP_Format/blob/main/UMP_Format.md
+class PART(Enum):
+    ONESIE_HEADER = 10
+    ONESIE_DATA = 11
+    MEDIA_HEADER = 20
+    MEDIA = 21
+    MEDIA_END = 22
+    LIVE_METADATA = 31
+    HOSTNAME_CHANGE_HINT = 32
+    LIVE_METADATA_PROMISE = 33
+    LIVE_METADATA_PROMISE_CANCELLATION = 34
+    NEXT_REQUEST_POLICY = 35
+    USTREAMER_VIDEO_AND_FORMAT_DATA = 36
+    FORMAT_SELECTION_CONFIG = 37
+    USTREAMER_SELECTED_MEDIA_STREAM = 38
+    FORMAT_INITIALIZATION_METADATA = 42
+    SABR_REDIRECT = 43
+    SABR_ERROR = 44
+    SABR_SEEK = 45
+    RELOAD_PLAYER_RESPONSE = 46
+    PLAYBACK_START_POLICY = 47
+    ALLOWED_CACHED_FORMATS = 48
+    START_BW_SAMPLING_HINT = 49
+    PAUSE_BW_SAMPLING_HINT = 50
+    SELECTABLE_FORMATS = 51
+    REQUEST_IDENTIFIER = 52
+    REQUEST_CANCELLATION_POLICY = 53
+    ONESIE_PREFETCH_REJECTION = 54
+    TIMELINE_CONTEXT = 55
+    REQUEST_PIPELINING = 56
+    SABR_CONTEXT_UPDATE = 57
+    STREAM_PROTECTION_STATUS = 58
+    SABR_CONTEXT_SENDING_POLICY = 59
+    LAWNMOWER_POLICY = 60
+    SABR_ACK = 61
+    END_OF_TRACK = 62
+    CACHE_LOAD_POLICY = 63
+    LAWNMOWER_MESSAGING_POLICY = 64
+    PREWARM_CONNECTION = 65
+
+
+class ServerAbrStream:
+    def __init__(self, stream, write_chunk: Callable):
+
+        self.stream = stream
+        self.write_chunk = write_chunk
+        self.po_token = self.stream.po_token
+        self.server_abr_streaming_url = self.stream.url
+        self.video_playback_ustreamer_config = self.stream.video_playback_ustreamer_config
+        self.totalDurationMs = int(self.stream.durationMs)
+        self.bytes_remaining = self.stream.filesize
+        self.initialized_formats = []
+        self.formats_by_key = {}
+        self.playback_cookie = None
+        self.header_id_to_format_key_map = {}
+        self.previous_sequences = {}
+
+
+    def emit(self, data):
+        for formatId in data['initialized_formats']:
+            if formatId['formatId']['itag'] == self.stream.itag:
+                media_chunks = formatId['mediaChunks']
+                for chunk in media_chunks:
+                    self.bytes_remaining -= len(chunk)
+                    self.write_chunk(chunk, self.bytes_remaining)
+
+    def start(self):
+
+        audio_format = [{'itag': self.stream.itag,
+                        'lastModified': int(self.stream.last_Modified),
+                        'xtags': self.stream.xtags}]  if self.stream.type == 'audio' else []
+
+
+        video_format = [{'itag': self.stream.itag,
+                        'lastModified': int(self.stream.last_Modified),
+                        'xtags': self.stream.xtags}] if self.stream.type == 'video' else []
+
+        client_abr_state = {
+            'lastManualDirection': 0,
+            'timeSinceLastManualFormatSelectionMs': 0,
+            'lastManualSelectedResolution': int(self.stream.resolution.replace('p', '')) if video_format else 720,
+            'stickyResolution': int(self.stream.resolution.replace('p', '')) if video_format else 720,
+            'playerTimeMs': 0,
+            'visibility': 0,
+            # 0 = BOTH, 1 = AUDIO (video-only is no longer supported by YouTube)
+            'enabledTrackTypesBitfield': 0 if video_format else 1
+        }
+        while client_abr_state['playerTimeMs'] < self.totalDurationMs:
+            data = self.fetch_media(client_abr_state, audio_format, video_format)
+
+            if data.get("sabr_error", None):
+                raise Sabr(data.get('sabr_error').type)
+
+            self.emit(data)
+
+            if client_abr_state['enabledTrackTypesBitfield'] == 0:
+                main_format = next((fmt for fmt in data['initialized_formats'] if "video" in (fmt.get("mimeType") or "")),
+                                   None)
+            else:
+                main_format = data['initialized_formats'][0] if data['initialized_formats'] else None
+
+            for fmt in data['initialized_formats']:
+                format_key = fmt["formatKey"]
+                sequence_numbers = [seq.get("sequenceNumber", 0) for seq in fmt["sequenceList"]]
+                self.previous_sequences[format_key] = sequence_numbers
+
+            if not main_format["sequenceList"]:
+                raise Sabr("Error getting chunks. The Abr server did not return any chunks")
+
+            if (
+                    not main_format or
+                    main_format["sequenceCount"] == main_format["sequenceList"][-1].get("sequenceNumber")
+            ):
+                break
+
+            total_sequence_duration = sum(seq.get("durationMs", 0) for seq in main_format["sequenceList"])
+            client_abr_state['playerTimeMs'] += total_sequence_duration
+
+    def fetch_media(self, client_abr_state, audio_format, video_format):
+        body = VideoPlaybackAbrRequest.encode({
+            'clientAbrState': client_abr_state,
+            'selectedAudioFormatIds': audio_format,
+            'selectedVideoFormatIds': video_format,
+            'selectedFormatIds': [fmt["formatId"] for fmt in self.initialized_formats],
+            'videoPlaybackUstreamerConfig': self.base64_to_u8(self.video_playback_ustreamer_config),
+            'streamerContext': {
+                'field5': [],
+                'field6': [],
+                'poToken': self.base64_to_u8(self.po_token) if self.po_token else None,
+                'playbackCookie': PlaybackCookie.encode(self.playback_cookie).finish() if self.playback_cookie else None,
+                'clientInfo': {
+                    'clientName': 1,
+                    'clientVersion': '2.2040620.05.00',
+                    'osName': 'Windows',
+                    'osVersion': '10.0'
+                }
+            },
+            'bufferedRanges': [fmt["_state"] for fmt in self.initialized_formats],
+            'field1000': []
+        }).finish()
+
+        request = Request(self.stream.url, method="POST", data=bytes(body))
+
+        return self.parse_ump_response(bytes(urlopen(request).read()))
+
+    def parse_ump_response(self, response):
+        self.header_id_to_format_key_map.clear()
+        for k, v  in enumerate(self.initialized_formats):
+            self.initialized_formats[k]['sequenceList'] = []
+            self.initialized_formats[k]['mediaChunks'] = []
+
+        sabr_error: Optional[SabrError] = None
+        sabr_redirect: Optional[SabrRedirect] = None
+        stream_protection_status: Optional[StreamProtectionStatus] = None
+
+        ump = UMP(ChunkedDataBuffer([response]))
+
+        def callback(part):
+            data = list(part['data'].chunks[0] if part['data'].chunks else [])
+
+            if part['type'] == PART.MEDIA_HEADER.value:
+                self.process_media_header(data)
+
+            elif part['type'] == PART.MEDIA.value:
+                self.process_media_data(part['data'])
+
+            elif part['type'] == PART.MEDIA_END.value:
+                self.process_end_of_media(part['data'])
+
+            elif part['type'] == PART.NEXT_REQUEST_POLICY.value:
+                self.process_next_request_policy(data)
+
+            elif part['type'] == PART.FORMAT_INITIALIZATION_METADATA.value:
+                self.process_format_initialization(data)
+
+            elif part['type'] == PART.SABR_ERROR.value:
+                nonlocal sabr_error
+                sabr_error = SabrError.decode(data)
+
+            elif part['type'] == PART.SABR_REDIRECT.value:
+                nonlocal sabr_redirect
+                sabr_redirect = self.process_sabr_redirect(data)
+
+            elif part['type'] == PART.STREAM_PROTECTION_STATUS.value:
+                nonlocal stream_protection_status
+                stream_protection_status = StreamProtectionStatus.decode(data)
+
+        ump.parse(callback)
+
+        return {
+            "initialized_formats": self.initialized_formats,
+            "stream_protection_status": stream_protection_status,
+            "sabr_redirect": sabr_redirect,
+            "sabr_error": sabr_error
+        }
+
+    def process_media_header(self, data):
+        media_header = MediaHeader.decode(data)
+
+        if not media_header.formatId:
+            return
+
+        format_key = self.get_format_key(media_header.formatId)
+        current_format = self.formats_by_key.get(format_key) or self.register_format(media_header)
+
+        if not current_format:
+            return
+
+        sequence_number = media_header.sequenceNumber
+        if sequence_number is not None:
+            if format_key in self.previous_sequences:
+                if sequence_number in self.previous_sequences[format_key]:
+                    return
+
+        header_id = media_header.headerId
+        if header_id is not None:
+            if header_id not in self.header_id_to_format_key_map:
+                self.header_id_to_format_key_map[header_id] = format_key
+
+        if not any(seq.get("sequenceNumber") == (media_header.sequenceNumber or 0) for seq in
+                   current_format["sequenceList"]):
+            current_format["sequenceList"].append({
+                "itag": media_header.itag,
+                "formatId": media_header.formatId,
+                "isInitSegment": media_header.isInitSeg,
+                "durationMs": media_header.durationMs,
+                "startMs": media_header.startMs,
+                "startDataRange": media_header.startRange,
+                "sequenceNumber": media_header.sequenceNumber,
+                "contentLength": media_header.contentLength,
+                "timeRange": media_header.timeRange
+            })
+
+            if isinstance(sequence_number, int):
+                current_format["_state"]["durationMs"] += media_header.durationMs
+                current_format["_state"]["endSegmentIndex"] += 1
+
+    def process_media_data(self, data):
+        header_id = data.get_uint8(0)
+        stream_data = data.split(1)['remaining_buffer']
+        format_key = self.header_id_to_format_key_map.get(header_id)
+        if not format_key:
+            return
+
+        current_format = self.formats_by_key.get(format_key)
+        if not current_format:
+            return
+
+        current_format['mediaChunks'].append(stream_data.chunks[0])
+
+    def process_end_of_media(self, data):
+        header_id = data.get_uint8(0)
+        self.header_id_to_format_key_map.pop(header_id, None)
+
+    def process_next_request_policy(self, data):
+        next_request_policy = NextRequestPolicy.decode(data)
+        self.playback_cookie = next_request_policy.playbackCookie
+
+    def process_format_initialization(self, data):
+        format_metadata = FormatInitializationMetadata.decode(data)
+        self.register_format(format_metadata)
+
+    def process_sabr_redirect(self, data):
+        sabr_redirect = SabrRedirect.decode(data)
+        if not sabr_redirect.url:
+            raise ValueError("Invalid SABR redirect")
+        self.server_abr_streaming_url = sabr_redirect.url
+        return sabr_redirect
+
+    @staticmethod
+    def get_format_key(format_id) -> str:
+        return f"{format_id['itag']};{format_id['lastModified']};"
+
+    def register_format(self, data):
+        if data.formatId is None:
+            return None
+
+        format_key = self.get_format_key(data.formatId)
+
+        if format_key not in self.formats_by_key:
+            format_ = {
+                "formatId": data.formatId,
+                "formatKey": format_key,
+                "durationMs": data.durationMs,
+                "mimeType": data.mimeType,
+                "sequenceCount": data.endSegmentNumber,
+                "sequenceList": [],
+                "mediaChunks": [],
+                "_state": {
+                    "formatId": data.formatId,
+                    "startTimeMs": 0,
+                    "durationMs": 0,
+                    "startSegmentIndex": 1,
+                    "endSegmentIndex": 0
+                }
+            }
+            self.initialized_formats.append(format_)
+            self.formats_by_key[format_key] = self.initialized_formats[-1]
+            return format_
+        return None
+
+    @staticmethod
+    def base64_to_u8(base64_str):
+        standard_base64 = base64_str.replace('-', '+').replace('_', '/')
+        padded_base64 = standard_base64 + '=' * ((4 - len(standard_base64) % 4) % 4)
+        byte_data = base64.b64decode(padded_base64)
+        return bytearray(byte_data)

--- a/pytubefix/sabr/core/server_abr_stream.py
+++ b/pytubefix/sabr/core/server_abr_stream.py
@@ -1,13 +1,15 @@
 # All credits to https://github.com/LuanRT/googlevideo
 
 import base64
+import logging
 from enum import Enum
 from typing import Optional
 from collections.abc import Callable
 from urllib.request import Request, urlopen
 
-from pytubefix.exceptions import Sabr
 from pytubefix.sabr.core.UMP import UMP
+from pytubefix.monostate import Monostate
+from pytubefix.exceptions import SABRError
 from pytubefix.sabr.video_streaming.sabr_error import SabrError
 from pytubefix.sabr.video_streaming.media_header import MediaHeader
 from pytubefix.sabr.core.chunked_data_buffer import ChunkedDataBuffer
@@ -18,8 +20,9 @@ from pytubefix.sabr.video_streaming.stream_protection_status import StreamProtec
 from pytubefix.sabr.video_streaming.video_playback_abr_request import VideoPlaybackAbrRequest
 from pytubefix.sabr.video_streaming.format_initialization_metadata import FormatInitializationMetadata
 
+logger = logging.getLogger(__name__)
 
-# https://github.com/gsuberland/UMP_Format/blob/main/UMP_Format.md
+# https://github.com/davidzeng0/innertube/blob/main/googlevideo/ump.md
 class PART(Enum):
     ONESIE_HEADER = 10
     ONESIE_DATA = 11
@@ -58,13 +61,16 @@ class PART(Enum):
     CACHE_LOAD_POLICY = 63
     LAWNMOWER_MESSAGING_POLICY = 64
     PREWARM_CONNECTION = 65
+    PLAYBACK_DEBUG_INFO = 66
+    SNACKBAR_MESSAGE = 67
 
 
 class ServerAbrStream:
-    def __init__(self, stream, write_chunk: Callable):
+    def __init__(self, stream, write_chunk: Callable, monostate: Monostate):
 
         self.stream = stream
         self.write_chunk = write_chunk
+        self.youtube = monostate.youtube
         self.po_token = self.stream.po_token
         self.server_abr_streaming_url = self.stream.url
         self.video_playback_ustreamer_config = self.stream.video_playback_ustreamer_config
@@ -75,6 +81,8 @@ class ServerAbrStream:
         self.playback_cookie = None
         self.header_id_to_format_key_map = {}
         self.previous_sequences = {}
+        self.RELOAD = False
+        self.maximum_reload_attempt = 3
 
 
     def emit(self, data):
@@ -106,11 +114,11 @@ class ServerAbrStream:
             # 0 = BOTH, 1 = AUDIO (video-only is no longer supported by YouTube)
             'enabledTrackTypesBitfield': 0 if video_format else 1
         }
-        while client_abr_state['playerTimeMs'] < self.totalDurationMs:
+        while client_abr_state['playerTimeMs'] < self.totalDurationMs or self.maximum_reload_attempt > 0:
             data = self.fetch_media(client_abr_state, audio_format, video_format)
 
             if data.get("sabr_error", None):
-                raise Sabr(data.get('sabr_error').type)
+                raise SABRError(data.get('sabr_error').type)
 
             self.emit(data)
 
@@ -127,8 +135,14 @@ class ServerAbrStream:
 
             protection_status: StreamProtectionStatus = data.get("stream_protection_status", None)
 
-            if not main_format.get("sequenceList", None):
-                raise Sabr(f"Error getting chunks. The Abr server did not return any chunks. Protection Status: "
+            if self.maximum_reload_attempt > 0 and self.RELOAD:
+                self.RELOAD = False
+                continue
+            elif self.maximum_reload_attempt <= 0:
+                raise SABRError("Maximum reload attempts reached")
+
+            if main_format is None or ("sequenceList" in main_format and not main_format.get("sequenceList", None)):
+                raise SABRError(f"Error getting chunks. The Abr server did not return any chunks. Protection Status: "
                            f"{protection_status.status if protection_status else None}, "
                            f"{protection_status.field2 if protection_status else None}")
 
@@ -155,16 +169,17 @@ class ServerAbrStream:
                 'playbackCookie': PlaybackCookie.encode(self.playback_cookie).finish() if self.playback_cookie else None,
                 'clientInfo': {
                     'clientName': 1,
-                    'clientVersion': '2.2040620.05.00',
+                    'clientVersion': '2.20250523.01.00',
                     'osName': 'Windows',
-                    'osVersion': '10.0'
+                    'osVersion': '10.0',
+                    'platform': 'DESKTOP'
                 }
             },
             'bufferedRanges': [fmt["_state"] for fmt in self.initialized_formats],
             'field1000': []
         }).finish()
 
-        request = Request(self.stream.url, method="POST", data=bytes(body))
+        request = Request(self.server_abr_streaming_url, method="POST", data=bytes(body))
 
         return self.parse_ump_response(bytes(urlopen(request).read()))
 
@@ -205,12 +220,37 @@ class ServerAbrStream:
             elif part['type'] == PART.SABR_REDIRECT.value:
                 nonlocal sabr_redirect
                 sabr_redirect = self.process_sabr_redirect(data)
+                logger.debug("SABR_REDIRECT")
 
             elif part['type'] == PART.STREAM_PROTECTION_STATUS.value:
                 nonlocal stream_protection_status
                 stream_protection_status = StreamProtectionStatus.decode(data)
+
+            elif part['type'] == PART.RELOAD_PLAYER_RESPONSE.value:
+                print("RELOAD_PLAYER_RESPONSE")
+                print(data)
+                self.RELOAD = True
+                self.maximum_reload_attempt -= 1
+                self.reload()
+
+            elif part["type"] == PART.PLAYBACK_START_POLICY.value:
+                # Unknown purpose and format
+                pass
+
+            elif part["type"] == PART.REQUEST_CANCELLATION_POLICY.value:
+                # Unknown purpose and format
+                pass
+
+            elif part["type"] == PART.SABR_CONTEXT_UPDATE.value:
+                print("SABR_CONTEXT_UPDATE")
+                print(data)
+                self.RELOAD = True
+                self.maximum_reload_attempt -= 1
+                self.reload()
+
             else:
-                print(part['type'])
+                print(part["type"])
+                print(data)
 
         ump.parse(callback)
 
@@ -325,6 +365,16 @@ class ServerAbrStream:
             self.formats_by_key[format_key] = self.initialized_formats[-1]
             return format_
         return None
+
+    def reload(self):
+        logger.debug("Refreshing SABR streaming URL")
+        self.youtube.vid_info = None
+        refresh_url = self.youtube.server_abr_streaming_url
+        if not refresh_url:
+            raise ValueError("Invalid SABR refresh")
+        self.server_abr_streaming_url = refresh_url
+        self.video_playback_ustreamer_config = self.youtube.video_playback_ustreamer_config
+
 
     @staticmethod
     def base64_to_u8(base64_str):

--- a/pytubefix/sabr/core/server_abr_stream.py
+++ b/pytubefix/sabr/core/server_abr_stream.py
@@ -125,8 +125,12 @@ class ServerAbrStream:
                 sequence_numbers = [seq.get("sequenceNumber", 0) for seq in fmt["sequenceList"]]
                 self.previous_sequences[format_key] = sequence_numbers
 
-            if not main_format["sequenceList"]:
-                raise Sabr("Error getting chunks. The Abr server did not return any chunks")
+            protection_status: StreamProtectionStatus = data.get("stream_protection_status", None)
+
+            if not main_format.get("sequenceList", None):
+                raise Sabr(f"Error getting chunks. The Abr server did not return any chunks. Protection Status: "
+                           f"{protection_status.status if protection_status else None}, "
+                           f"{protection_status.field2 if protection_status else None}")
 
             if (
                     not main_format or
@@ -205,6 +209,8 @@ class ServerAbrStream:
             elif part['type'] == PART.STREAM_PROTECTION_STATUS.value:
                 nonlocal stream_protection_status
                 stream_protection_status = StreamProtectionStatus.decode(data)
+            else:
+                print(part['type'])
 
         ump.parse(callback)
 

--- a/pytubefix/sabr/core/server_abr_stream.py
+++ b/pytubefix/sabr/core/server_abr_stream.py
@@ -233,7 +233,7 @@ class ServerAbrStream:
                 stream_protection_status = StreamProtectionStatus.decode(data)
 
             elif part['type'] == PART.RELOAD_PLAYER_RESPONSE.value:
-                print("RELOAD_PLAYER_RESPONSE")
+                logger.debug("RELOAD_PLAYER_RESPONSE")
                 self.reload()
 
             elif part["type"] == PART.PLAYBACK_START_POLICY.value:
@@ -243,13 +243,9 @@ class ServerAbrStream:
                 pass
 
             elif part["type"] == PART.SABR_CONTEXT_UPDATE.value:
-                print("SABR_CONTEXT_UPDATE")
-                print(data)
-                self.reload()
-
-            else:
-                print(part["type"])
-                print(data)
+                # TODO: Find out how to implement this part
+                logger.debug("SABR_CONTEXT_UPDATE")
+                ...
 
         ump.parse(callback)
 

--- a/pytubefix/sabr/proto.py
+++ b/pytubefix/sabr/proto.py
@@ -1,0 +1,335 @@
+import struct
+from typing import Callable
+
+
+def assert_uint32(value):
+    if not (0 <= value <= 0xFFFFFFFF):
+        raise ValueError("Value is not a valid uint32")
+
+def assert_int32(value):
+    if not (-0x80000000 <= value <= 0x7FFFFFFF):
+        raise ValueError("Value is not a valid int32")
+
+def varint32write(value, buf):
+    while value > 0x7F:
+        buf.append((value & 0x7F) | 0x80)
+        value >>= 7
+    buf.append(value)
+
+def varint64write(lo, hi, buf):
+    for _ in range(9):  # max 10 bytes
+        if hi == 0 and lo < 0x80:
+            buf.append(lo)
+            return
+        buf.append((lo & 0x7F) | 0x80)
+        carry = (lo >> 7)
+        lo = ((hi << 25) | (lo >> 7)) & 0xFFFFFFFF
+        hi = hi >> 7
+    buf.append(lo)
+
+def read_varint32(buf: bytes, pos: int):
+    result = shift = 0
+    while True:
+        if pos >= len(buf):
+            raise EOFError("Unexpected end of buffer while reading varint32")
+        b = buf[pos]
+        pos += 1
+        result |= (b & 0x7F) << shift
+        if not (b & 0x80):
+            break
+        shift += 7
+        if shift > 35:
+            raise ValueError("Varint32 too long")
+    return result, pos
+
+def read_varint64(buf, pos):
+    low_bits = 0
+    high_bits = 0
+
+
+    for shift in range(0, 28, 7):
+        b = buf[pos]
+        pos += 1
+        low_bits |= (b & 0x7F) << shift
+        if (b & 0x80) == 0:
+            return low_bits, high_bits, pos
+
+    middle_byte = buf[pos]
+    pos += 1
+    low_bits |= (middle_byte & 0x0F) << 28
+    high_bits = (middle_byte & 0x70) >> 4
+    if (middle_byte & 0x80) == 0:
+        return low_bits, high_bits, pos
+
+    for shift in range(3, 32, 7):
+        b = buf[pos]
+        pos += 1
+        high_bits |= (b & 0x7F) << shift
+        if (b & 0x80) == 0:
+            return low_bits, high_bits, pos
+
+    raise ValueError("invalid varint")
+
+def decode_int64(lo: int, hi: int) -> int:
+    value = (hi << 32) | lo
+    if hi & 0x80000000:
+        value -= 1 << 64
+    return value
+
+def decode_uint64(lo: int, hi: int) -> int:
+    return (hi << 32) | lo
+
+
+class ProtoInt64:
+    @staticmethod
+    def enc(value: int):
+        """Signed 64-bit -> lo/hi pair (int32 each)."""
+        if value < 0:
+            value += 1 << 64
+        lo = value & 0xFFFFFFFF
+        hi = (value >> 32) & 0xFFFFFFFF
+        return {'lo': lo, 'hi': hi}
+
+    @staticmethod
+    def uEnc(value: int):
+        """Unsigned 64-bit -> lo/hi pair (int32 each)."""
+        lo = value & 0xFFFFFFFF
+        hi = (value >> 32) & 0xFFFFFFFF
+        return {'lo': lo, 'hi': hi}
+
+class BinaryWriter:
+    def __init__(self, encode_utf8: Callable[[str], bytes] = lambda s: s.encode('utf-8')):
+        self.encode_utf8 = encode_utf8
+        self.stack = []
+        self.chunks = []
+        self.buf = bytearray()
+
+    def finish(self) -> bytes:
+        if self.buf:
+            self.chunks.append(bytes(self.buf))
+            self.buf.clear()
+        return b''.join(self.chunks)
+
+    def fork(self):
+        self.stack.append((self.chunks, self.buf))
+        self.chunks = []
+        self.buf = bytearray()
+        return self
+
+    def join(self):
+        chunk = self.finish()
+        if not self.stack:
+            raise RuntimeError("Invalid state, fork stack empty")
+        self.chunks, self.buf = self.stack.pop()
+        self.uint32(len(chunk))
+        return self.raw(chunk)
+
+    def tag(self, field_no: int, wire_type: int):
+        return self.uint32((field_no << 3) | wire_type)
+
+    def raw(self, chunk: bytes):
+        if self.buf:
+            self.chunks.append(bytes(self.buf))
+            self.buf.clear()
+        self.chunks.append(chunk)
+        return self
+
+    def uint32(self, value: int):
+        assert_uint32(value)
+        varint32write(value, self.buf)
+        return self
+
+    def int32(self, value: int):
+        assert_int32(value)
+        varint32write(value & 0xFFFFFFFF, self.buf)
+        return self
+
+    def bool(self, value: bool):
+        self.buf.append(1 if value else 0)
+        return self
+
+    def bytes(self, value: bytes):
+        self.uint32(len(value))
+        return self.raw(value)
+
+    def string(self, value: str):
+        encoded = self.encode_utf8(value)
+        self.uint32(len(encoded))
+        return self.raw(encoded)
+
+    def float(self, value: float):
+        self.raw(struct.pack('<f', value))
+        return self
+
+    def double(self, value: float):
+        self.raw(struct.pack('<d', value))
+        return self
+
+    def fixed32(self, value: int):
+        assert_uint32(value)
+        self.raw(struct.pack('<I', value))
+        return self
+
+    def sfixed32(self, value: int):
+        assert_int32(value)
+        self.raw(struct.pack('<i', value))
+        return self
+
+    def sint32(self, value: int):
+        assert_int32(value)
+        encoded = (value << 1) ^ (value >> 31)
+        varint32write(encoded, self.buf)
+        return self
+
+    def sfixed64(self, value: int):
+        tc = ProtoInt64.enc(value)
+        self.raw(struct.pack('<ii', tc['lo'], tc['hi']))
+        return self
+
+    def fixed64(self, value: int):
+        tc = ProtoInt64.uEnc(value)
+        self.raw(struct.pack('<II', tc['lo'], tc['hi']))
+        return self
+
+    def int64(self, value: int):
+        tc = ProtoInt64.enc(value)
+        varint64write(tc['lo'], tc['hi'], self.buf)
+        return self
+
+    def sint64(self, value: int):
+        tc = ProtoInt64.enc(value)
+        sign = tc['hi'] >> 31
+        lo = (tc['lo'] << 1) ^ sign
+        hi = ((tc['hi'] << 1) | (tc['lo'] >> 31)) ^ sign
+        varint64write(lo, hi, self.buf)
+        return self
+
+    def uint64(self, value: int):
+        tc = ProtoInt64.uEnc(value)
+        varint64write(tc['lo'], tc['hi'], self.buf)
+        return self
+
+
+class BinaryReader:
+    def __init__(self, buf, decode_utf8: Callable[[bytes], str] = lambda b: b.decode('utf-8')):
+        if isinstance(buf, list):
+            buf = bytes(buf)
+        elif isinstance(buf, bytearray):
+            buf = bytes(buf)
+        elif not isinstance(buf, bytes):
+            raise TypeError(f"Unsupported buffer type: {type(buf)}")
+
+        self.decode_utf8 = decode_utf8
+        self.buf = buf
+        self.len = len(buf)
+        self.pos = 0
+
+    def tag(self):
+        tag, self.pos = read_varint32(self.buf, self.pos)
+        field_no = tag >> 3
+        wire_type = tag & 0x7
+        if field_no <= 0 or wire_type < 0 or wire_type > 5:
+            raise ValueError(f"Illegal tag: field no {field_no} wire type {wire_type}")
+        return field_no, wire_type
+
+    def skip(self, wire_type: int, field_no=None):
+        start = self.pos
+        if wire_type == 0:  # Varint
+            while self.buf[self.pos] & 0x80:
+                self.pos += 1
+            self.pos += 1
+        elif wire_type == 1:  # 64-bit
+            self.pos += 8
+        elif wire_type == 2:  # Length-delimited
+            length, self.pos = read_varint32(self.buf, self.pos)
+            self.pos += length
+        elif wire_type == 3:  # Start group
+            while True:
+                fn, wt = self.tag()
+                if wt == 4:  # End group
+                    if field_no is not None and fn != field_no:
+                        raise ValueError("Invalid end group tag")
+                    break
+                self.skip(wt, fn)
+        elif wire_type == 5:  # 32-bit
+            self.pos += 4
+        else:
+            raise ValueError(f"Can't skip unknown wire type {wire_type}")
+        self.assert_bounds()
+        return self.buf[start:self.pos]
+
+    def assert_bounds(self):
+        if self.pos > self.len:
+            raise EOFError("Premature EOF")
+
+    def uint32(self):
+        value, self.pos = read_varint32(self.buf, self.pos)
+        return value
+
+    def int32(self):
+        return self.uint32() | 0
+
+    def sint32(self):
+        value = self.uint32()
+        return (value >> 1) ^ -(value & 1)
+
+    def varint64(self):
+        lo, hi, self.pos = read_varint64(self.buf, self.pos)
+        return lo, hi
+
+    def int64(self):
+        return decode_int64(*self.varint64())
+
+    def uint64(self):
+        return decode_uint64(*self.varint64())
+
+    def sint64(self):
+        lo, hi = self.varint64()
+        sign = -(lo & 1)
+        lo = ((lo >> 1) | ((hi & 1) << 31)) ^ sign
+        hi = (hi >> 1) ^ sign
+        return decode_int64(lo, hi)
+
+    def bool(self):
+        lo, hi = self.varint64()
+        return lo != 0 or hi != 0
+
+    def fixed32(self):
+        value = struct.unpack_from('<I', self.buf, self.pos)[0]
+        self.pos += 4
+        return value
+
+    def sfixed32(self):
+        value = struct.unpack_from('<i', self.buf, self.pos)[0]
+        self.pos += 4
+        return value
+
+    def fixed64(self):
+        lo = self.sfixed32()
+        hi = self.sfixed32()
+        return decode_uint64(lo, hi)
+
+    def sfixed64(self):
+        lo = self.sfixed32()
+        hi = self.sfixed32()
+        return decode_int64(lo, hi)
+
+    def float(self):
+        value = struct.unpack_from('<f', self.buf, self.pos)[0]
+        self.pos += 4
+        return value
+
+    def double(self):
+        value = struct.unpack_from('<d', self.buf, self.pos)[0]
+        self.pos += 8
+        return value
+
+    def bytes(self):
+        length = self.uint32()
+        start = self.pos
+        self.pos += length
+        self.assert_bounds()
+        return self.buf[start:self.pos]
+
+    def string(self):
+        return self.decode_utf8(self.bytes())

--- a/pytubefix/sabr/video_streaming/buffered_range.py
+++ b/pytubefix/sabr/video_streaming/buffered_range.py
@@ -1,0 +1,178 @@
+# All credits to https://github.com/LuanRT/googlevideo
+
+from pytubefix.sabr.common import FormatId
+from pytubefix.sabr.proto import BinaryWriter, BinaryReader
+from pytubefix.sabr.video_streaming.time_range import TimeRange
+
+
+def create_base_buffered_range():
+    return {
+        "formatId": None,
+        "startTimeMs": 0,
+        "durationMs": 0,
+        "startSegmentIndex": 0,
+        "endSegmentIndex": 0,
+        "timeRange": None,
+        "field9": None,
+        "field11": None,
+        "field12": None
+    }
+
+
+def create_base_kob():
+    return {"EW": []}
+
+
+def create_base_kob_pa():
+    return {"videoId": "", "lmt": 0}
+
+
+def create_base_ypa():
+    return {"field1": 0, "field2": 0, "field3": 0}
+
+
+class Kob_Pa:
+    @staticmethod
+    def encode(message, writer=None):
+        writer = writer or BinaryWriter()
+        if message.get("videoId"):
+            writer.uint32(10).string(message["videoId"])
+        if message.get("lmt", 0) != 0:
+            writer.uint32(16).uint64(message["lmt"])
+        return writer
+
+    @staticmethod
+    def decode(reader, length):
+        end = reader.pos + length if length is not None else reader.len
+        message = create_base_kob_pa()
+        while reader.pos < end:
+            tag = reader.uint32()
+            if tag == 10:
+                message["videoId"] = reader.string()
+            elif tag == 16:
+                message["lmt"] = long_to_number(reader.uint64())
+            elif (tag & 7) == 4 or tag == 0:
+                break
+            else:
+                reader.skip(tag & 7)
+        return message
+
+
+class Kob:
+    @staticmethod
+    def encode(message, writer=None):
+        writer = writer or BinaryWriter()
+        for v in message.get("EW", []):
+            Kob_Pa.encode(v, writer.uint32(10).fork()).join()
+        return writer
+
+    @staticmethod
+    def decode(reader, length):
+        end = reader.pos + length if length is not None else reader.len
+        message = create_base_kob()
+        while reader.pos < end:
+            tag = reader.uint32()
+            if tag == 10:
+                message["EW"].append(Kob_Pa.decode(reader, reader.uint32()))
+            elif (tag & 7) == 4 or tag == 0:
+                break
+            else:
+                reader.skip(tag & 7)
+        return message
+
+
+class YPa:
+    @staticmethod
+    def encode(message, writer=None):
+        writer = writer or BinaryWriter()
+        if message.get("field1", 0) != 0:
+            writer.uint32(8).int32(message["field1"])
+        if message.get("field2", 0) != 0:
+            writer.uint32(16).int32(message["field2"])
+        if message.get("field3", 0) != 0:
+            writer.uint32(24).int32(message["field3"])
+        return writer
+
+    @staticmethod
+    def decode(reader, length):
+        end = reader.pos + length if length is not None else reader.len
+        message = create_base_ypa()
+        while reader.pos < end:
+            tag = reader.uint32()
+            if tag == 8:
+                message["field1"] = reader.int32()
+            elif tag == 16:
+                message["field2"] = reader.int32()
+            elif tag == 24:
+                message["field3"] = reader.int32()
+            elif (tag & 7) == 4 or tag == 0:
+                break
+            else:
+                reader.skip(tag & 7)
+        return message
+
+
+class BufferedRange:
+    @staticmethod
+    def encode(message, writer=None):
+        writer = writer or BinaryWriter()
+        if message.get("formatId") is not None:
+            FormatId.encode(message["formatId"], writer.uint32(10).fork()).join()
+        if message.get("startTimeMs", 0) != 0:
+            writer.uint32(16).int64(message["startTimeMs"])
+        if message.get("durationMs", 0) != 0:
+            writer.uint32(24).int64(message["durationMs"])
+        if message.get("startSegmentIndex", 0) != 0:
+            writer.uint32(32).int32(message["startSegmentIndex"])
+        if message.get("endSegmentIndex", 0) != 0:
+            writer.uint32(40).int32(message["endSegmentIndex"])
+        if message.get("timeRange") is not None:
+            TimeRange.encode(message["timeRange"], writer.uint32(50).fork()).join()
+        if message.get("field9") is not None:
+            Kob.encode(message["field9"], writer.uint32(74).fork()).join()
+        if message.get("field11") is not None:
+            YPa.encode(message["field11"], writer.uint32(90).fork()).join()
+        if message.get("field12") is not None:
+            YPa.encode(message["field12"], writer.uint32(98).fork()).join()
+        return writer
+
+    @staticmethod
+    def decode(reader, length):
+        if not isinstance(reader, BinaryReader):
+            reader = BinaryReader(reader)
+        end = reader.pos + length if length is not None else reader.len
+        message = create_base_buffered_range()
+        while reader.pos < end:
+            tag = reader.uint32()
+            field_num = tag >> 3
+            if field_num == 1 and tag == 10:
+                message["formatId"] = FormatId.decode(reader, reader.uint32())
+            elif field_num == 2 and tag == 16:
+                message["startTimeMs"] = long_to_number(reader.int64())
+            elif field_num == 3 and tag == 24:
+                message["durationMs"] = long_to_number(reader.int64())
+            elif field_num == 4 and tag == 32:
+                message["startSegmentIndex"] = reader.int32()
+            elif field_num == 5 and tag == 40:
+                message["endSegmentIndex"] = reader.int32()
+            elif field_num == 6 and tag == 50:
+                message["timeRange"] = TimeRange.decode(reader, reader.uint32())
+            elif field_num == 9 and tag == 74:
+                message["field9"] = Kob.decode(reader, reader.uint32())
+            elif field_num == 11 and tag == 90:
+                message["field11"] = YPa.decode(reader, reader.uint32())
+            elif field_num == 12 and tag == 98:
+                message["field12"] = YPa.decode(reader, reader.uint32())
+            elif (tag & 7) == 4 or tag == 0:
+                break
+            else:
+                reader.skip(tag & 7)
+        return message
+
+def long_to_number(int64_value):
+    value = int(str(int64_value))
+    if value > (2 ** 53 - 1):
+        raise OverflowError("Value is larger than 9007199254740991")
+    if value < -(2 ** 53 - 1):
+        raise OverflowError("Value is smaller than -9007199254740991")
+    return value

--- a/pytubefix/sabr/video_streaming/buffered_range.py
+++ b/pytubefix/sabr/video_streaming/buffered_range.py
@@ -18,20 +18,12 @@ def create_base_buffered_range():
         "field12": None
     }
 
-
-def create_base_kob():
-    return {"EW": []}
-
-
-def create_base_kob_pa():
-    return {"videoId": "", "lmt": 0}
-
-
-def create_base_ypa():
-    return {"field1": 0, "field2": 0, "field3": 0}
-
-
 class Kob_Pa:
+
+    def __init__(self):
+        self.videoId = ""
+        self.lmt = 0
+
     @staticmethod
     def encode(message, writer=None):
         writer = writer or BinaryWriter()
@@ -42,15 +34,20 @@ class Kob_Pa:
         return writer
 
     @staticmethod
-    def decode(reader, length):
-        end = reader.pos + length if length is not None else reader.len
-        message = create_base_kob_pa()
+    def decode(input_data, length=None):
+        reader = input_data if isinstance(input_data, BinaryReader) else BinaryReader(input_data)
+        end = reader.len if length is None else reader.pos + length
+
+        message = Kob_Pa()
         while reader.pos < end:
             tag = reader.uint32()
-            if tag == 10:
-                message["videoId"] = reader.string()
-            elif tag == 16:
-                message["lmt"] = long_to_number(reader.uint64())
+            field_num = tag >> 3
+
+            if field_num == 1 and tag == 10:
+                message.videoId = reader.string()
+                continue
+            elif field_num == 2 and tag == 16:
+                message.lmt = long_to_number(reader.uint64())
             elif (tag & 7) == 4 or tag == 0:
                 break
             else:
@@ -59,6 +56,10 @@ class Kob_Pa:
 
 
 class Kob:
+
+    def __init__(self):
+        self.EW = []
+
     @staticmethod
     def encode(message, writer=None):
         writer = writer or BinaryWriter()
@@ -67,13 +68,19 @@ class Kob:
         return writer
 
     @staticmethod
-    def decode(reader, length):
-        end = reader.pos + length if length is not None else reader.len
-        message = create_base_kob()
+    def decode(input_data, length=None):
+        reader = input_data if isinstance(input_data, BinaryReader) else BinaryReader(input_data)
+        end = reader.len if length is None else reader.pos + length
+
+        message = Kob()
         while reader.pos < end:
             tag = reader.uint32()
-            if tag == 10:
-                message["EW"].append(Kob_Pa.decode(reader, reader.uint32()))
+            field_num = tag >> 3
+
+            if field_num == 1 and tag == 10:
+                message.EW.append(Kob_Pa.decode(reader, reader.uint32()))
+                continue
+
             elif (tag & 7) == 4 or tag == 0:
                 break
             else:
@@ -82,6 +89,12 @@ class Kob:
 
 
 class YPa:
+
+    def __init__(self):
+        self.field1 = 0
+        self.field2 = 0
+        self.field3 = 0
+
     @staticmethod
     def encode(message, writer=None):
         writer = writer or BinaryWriter()
@@ -94,17 +107,25 @@ class YPa:
         return writer
 
     @staticmethod
-    def decode(reader, length):
-        end = reader.pos + length if length is not None else reader.len
-        message = create_base_ypa()
+    def decode(input_data, length=None):
+        reader = input_data if isinstance(input_data, BinaryReader) else BinaryReader(input_data)
+        end = reader.len if length is None else reader.pos + length
+
+        message = YPa()
         while reader.pos < end:
             tag = reader.uint32()
-            if tag == 8:
-                message["field1"] = reader.int32()
-            elif tag == 16:
-                message["field2"] = reader.int32()
-            elif tag == 24:
-                message["field3"] = reader.int32()
+            field_num = tag >> 3
+
+            if field_num == 1 and tag == 8:
+                message.field1 = reader.int32()
+                continue
+            elif field_num == 2 and tag == 16:
+                message.field2 = reader.int32()
+                continue
+            elif field_num == 3 and tag == 24:
+                message.field3 = reader.int32()
+                continue
+
             elif (tag & 7) == 4 or tag == 0:
                 break
             else:
@@ -137,32 +158,42 @@ class BufferedRange:
         return writer
 
     @staticmethod
-    def decode(reader, length):
-        if not isinstance(reader, BinaryReader):
-            reader = BinaryReader(reader)
-        end = reader.pos + length if length is not None else reader.len
+    def decode(input_data, length=None):
+        reader = input_data if isinstance(input_data, BinaryReader) else BinaryReader(input_data)
+        end = reader.len if length is None else reader.pos + length
+
         message = create_base_buffered_range()
         while reader.pos < end:
             tag = reader.uint32()
             field_num = tag >> 3
+
             if field_num == 1 and tag == 10:
                 message["formatId"] = FormatId.decode(reader, reader.uint32())
+                continue
             elif field_num == 2 and tag == 16:
                 message["startTimeMs"] = long_to_number(reader.int64())
+                continue
             elif field_num == 3 and tag == 24:
                 message["durationMs"] = long_to_number(reader.int64())
+                continue
             elif field_num == 4 and tag == 32:
                 message["startSegmentIndex"] = reader.int32()
+                continue
             elif field_num == 5 and tag == 40:
                 message["endSegmentIndex"] = reader.int32()
+                continue
             elif field_num == 6 and tag == 50:
                 message["timeRange"] = TimeRange.decode(reader, reader.uint32())
+                continue
             elif field_num == 9 and tag == 74:
                 message["field9"] = Kob.decode(reader, reader.uint32())
+                continue
             elif field_num == 11 and tag == 90:
                 message["field11"] = YPa.decode(reader, reader.uint32())
+                continue
             elif field_num == 12 and tag == 98:
                 message["field12"] = YPa.decode(reader, reader.uint32())
+                continue
             elif (tag & 7) == 4 or tag == 0:
                 break
             else:

--- a/pytubefix/sabr/video_streaming/client_abr_state.py
+++ b/pytubefix/sabr/video_streaming/client_abr_state.py
@@ -1,0 +1,264 @@
+# All credits to https://github.com/LuanRT/googlevideo
+
+from pytubefix.sabr.proto import BinaryWriter, BinaryReader
+
+
+class ClientAbrState:
+
+    @staticmethod
+    def create_base_client_abr_state():
+        return {
+            "timeSinceLastManualFormatSelectionMs": 0,
+            "lastManualDirection": 0,
+            "lastManualSelectedResolution": 0,
+            "detailedNetworkType": 0,
+            "clientViewportWidth": 0,
+            "clientViewportHeight": 0,
+            "clientBitrateCapBytesPerSec": 0,
+            "stickyResolution": 0,
+            "clientViewportIsFlexible": False,
+            "bandwidthEstimate": 0,
+            "minAudioQuality": 0,
+            "maxAudioQuality": 0,
+            "videoQualitySetting": 0,
+            "audioRoute": 0,
+            "playerTimeMs": 0,
+            "timeSinceLastSeek": 0,
+            "dataSaverMode": False,
+            "networkMeteredState": 0,
+            "visibility": 0,
+            "playbackRate": 0,
+            "elapsedWallTimeMs": 0,
+            "mediaCapabilities": bytearray(),
+            "timeSinceLastActionMs": 0,
+            "enabledTrackTypesBitfield": 0,
+            "maxPacingRate": 0,
+            "playerState": 0,
+            "drcEnabled": False,
+            "Jda": 0,
+            "qw": 0,
+            "Ky": 0,
+            "sabrReportRequestCancellationInfo": 0,
+            "l": False,
+            "G7": 0,
+            "preferVp9": False,
+            "qj": 0,
+            "Hx": 0,
+            "isPrefetch": False,
+            "sabrSupportQualityConstraints": 0,
+            "sabrLicenseConstraint": bytearray(),
+            "allowProximaLiveLatency": 0,
+            "sabrForceProxima": 0,
+            "Tqb": 0,
+            "sabrForceMaxNetworkInterruptionDurationMs": 0,
+            "audioTrackId": ""
+        }
+
+    @staticmethod
+    def encode(message: dict, writer=None):
+        if writer is None:
+            writer = BinaryWriter()
+
+        if message.get("timeSinceLastManualFormatSelectionMs", 0):
+            writer.uint32(104).int64(message["timeSinceLastManualFormatSelectionMs"])
+        if message.get("lastManualDirection", 0):
+            writer.uint32(112).sint32(message["lastManualDirection"])
+        if message.get("lastManualSelectedResolution", 0):
+            writer.uint32(128).int32(message["lastManualSelectedResolution"])
+        if message.get("detailedNetworkType", 0):
+            writer.uint32(136).int32(message["detailedNetworkType"])
+        if message.get("clientViewportWidth", 0):
+            writer.uint32(144).int32(message["clientViewportWidth"])
+        if message.get("clientViewportHeight", 0):
+            writer.uint32(152).int32(message["clientViewportHeight"])
+        if message.get("clientBitrateCapBytesPerSec", 0):
+            writer.uint32(160).int64(message["clientBitrateCapBytesPerSec"])
+        if message.get("stickyResolution", 0):
+            writer.uint32(168).int32(message["stickyResolution"])
+        if message.get("clientViewportIsFlexible", False):
+            writer.uint32(176).bool(message["clientViewportIsFlexible"])
+        if message.get("bandwidthEstimate", 0):
+            writer.uint32(184).int64(message["bandwidthEstimate"])
+        if message.get("minAudioQuality", 0):
+            writer.uint32(192).int32(message["minAudioQuality"])
+        if message.get("maxAudioQuality", 0):
+            writer.uint32(200).int32(message["maxAudioQuality"])
+        if message.get("videoQualitySetting", 0):
+            writer.uint32(208).int32(message["videoQualitySetting"])
+        if message.get("audioRoute", 0):
+            writer.uint32(216).int32(message["audioRoute"])
+        if message.get("playerTimeMs", 0):
+            writer.uint32(224).int64(message["playerTimeMs"])
+        if message.get("timeSinceLastSeek", 0):
+            writer.uint32(232).int64(message["timeSinceLastSeek"])
+        if message.get("dataSaverMode", False):
+            writer.uint32(240).bool(message["dataSaverMode"])
+        if message.get("networkMeteredState", 0):
+            writer.uint32(256).int32(message["networkMeteredState"])
+        if message.get("visibility", 0):
+            writer.uint32(272).int32(message["visibility"])
+        if message.get("playbackRate", 0):
+            writer.uint32(285).float(message["playbackRate"])
+        if message.get("elapsedWallTimeMs", 0):
+            writer.uint32(288).int64(message["elapsedWallTimeMs"])
+        if message.get("mediaCapabilities", b''):
+            writer.uint32(306).bytes(message["mediaCapabilities"])
+        if message.get("timeSinceLastActionMs", 0):
+            writer.uint32(312).int64(message["timeSinceLastActionMs"])
+        if message.get("enabledTrackTypesBitfield", 0):
+            writer.uint32(320).int32(message["enabledTrackTypesBitfield"])
+        if message.get("maxPacingRate", 0):
+            writer.uint32(344).int32(message["maxPacingRate"])
+        if message.get("playerState", 0):
+            writer.uint32(352).int64(message["playerState"])
+        if message.get("drcEnabled", False):
+            writer.uint32(368).bool(message["drcEnabled"])
+        if message.get("Jda", 0):
+            writer.uint32(384).int32(message["Jda"])
+        if message.get("qw", 0):
+            writer.uint32(400).int32(message["qw"])
+        if message.get("Ky", 0):
+            writer.uint32(408).int32(message["Ky"])
+        if message.get("sabrReportRequestCancellationInfo", 0):
+            writer.uint32(432).int32(message["sabrReportRequestCancellationInfo"])
+        if message.get("l", False):
+            writer.uint32(448).bool(message["l"])
+        if message.get("G7", 0):
+            writer.uint32(456).int64(message["G7"])
+        if message.get("preferVp9", False):
+            writer.uint32(464).bool(message["preferVp9"])
+        if message.get("qj", 0):
+            writer.uint32(472).int32(message["qj"])
+        if message.get("Hx", 0):
+            writer.uint32(480).int32(message["Hx"])
+        if message.get("isPrefetch", False):
+            writer.uint32(488).bool(message["isPrefetch"])
+        if message.get("sabrSupportQualityConstraints", 0):
+            writer.uint32(496).int32(message["sabrSupportQualityConstraints"])
+        if message.get("sabrLicenseConstraint", b''):
+            writer.uint32(506).bytes(message["sabrLicenseConstraint"])
+        if message.get("allowProximaLiveLatency", 0):
+            writer.uint32(512).int32(message["allowProximaLiveLatency"])
+        if message.get("sabrForceProxima", 0):
+            writer.uint32(528).int32(message["sabrForceProxima"])
+        if message.get("Tqb", 0):
+            writer.uint32(536).int32(message["Tqb"])
+        if message.get("sabrForceMaxNetworkInterruptionDurationMs", 0):
+            writer.uint32(544).int64(message["sabrForceMaxNetworkInterruptionDurationMs"])
+        if message.get("audioTrackId", ""):
+            writer.uint32(554).string(message["audioTrackId"])
+
+        return writer
+
+    @staticmethod
+    def decode(input_data, length=None):
+        reader = input_data if isinstance(input_data, BinaryReader) else BinaryReader(input_data)
+        end = reader.len if length is None else reader.pos + length
+        message = ClientAbrState.create_base_client_abr_state()
+
+        while reader.pos < end:
+            tag = reader.uint32()
+            field_number = tag >> 3
+
+            if field_number == 13 and tag == 104:
+                message['timeSinceLastManualFormatSelectionMs'] = long_to_number(reader.int64())
+            elif field_number == 14 and tag == 112:
+                message['lastManualDirection'] = reader.sint32()
+            elif field_number == 16 and tag == 128:
+                message['lastManualSelectedResolution'] = reader.int32()
+            elif field_number == 17 and tag == 136:
+                message['detailedNetworkType'] = reader.int32()
+            elif field_number == 18 and tag == 144:
+                message['clientViewportWidth'] = reader.int32()
+            elif field_number == 19 and tag == 152:
+                message['clientViewportHeight'] = reader.int32()
+            elif field_number == 20 and tag == 160:
+                message['clientBitrateCapBytesPerSec'] = long_to_number(reader.int64())
+            elif field_number == 21 and tag == 168:
+                message['stickyResolution'] = reader.int32()
+            elif field_number == 22 and tag == 176:
+                message['clientViewportIsFlexible'] = reader.bool()
+            elif field_number == 23 and tag == 184:
+                message['bandwidthEstimate'] = long_to_number(reader.int64())
+            elif field_number == 24 and tag == 192:
+                message['minAudioQuality'] = reader.int32()
+            elif field_number == 25 and tag == 200:
+                message['maxAudioQuality'] = reader.int32()
+            elif field_number == 26 and tag == 208:
+                message['videoQualitySetting'] = reader.int32()
+            elif field_number == 27 and tag == 216:
+                message['audioRoute'] = reader.int32()
+            elif field_number == 28 and tag == 224:
+                message['playerTimeMs'] = long_to_number(reader.int64())
+            elif field_number == 29 and tag == 232:
+                message['timeSinceLastSeek'] = long_to_number(reader.int64())
+            elif field_number == 30 and tag == 240:
+                message['dataSaverMode'] = reader.bool()
+            elif field_number == 32 and tag == 256:
+                message['networkMeteredState'] = reader.int32()
+            elif field_number == 34 and tag == 272:
+                message['visibility'] = reader.int32()
+            elif field_number == 35 and tag == 285:
+                message['playbackRate'] = reader.float()
+            elif field_number == 36 and tag == 288:
+                message['elapsedWallTimeMs'] = long_to_number(reader.int64())
+            elif field_number == 38 and tag == 306:
+                message['mediaCapabilities'] = reader.bytes()
+            elif field_number == 39 and tag == 312:
+                message['timeSinceLastActionMs'] = long_to_number(reader.int64())
+            elif field_number == 40 and tag == 320:
+                message['enabledTrackTypesBitfield'] = reader.int32()
+            elif field_number == 43 and tag == 344:
+                message['maxPacingRate'] = reader.int32()
+            elif field_number == 44 and tag == 352:
+                message['playerState'] = long_to_number(reader.int64())
+            elif field_number == 46 and tag == 368:
+                message['drcEnabled'] = reader.bool()
+            elif field_number == 48 and tag == 384:
+                message['Jda'] = reader.int32()
+            elif field_number == 50 and tag == 400:
+                message['qw'] = reader.int32()
+            elif field_number == 51 and tag == 408:
+                message['Ky'] = reader.int32()
+            elif field_number == 54 and tag == 432:
+                message['sabrReportRequestCancellationInfo'] = reader.int32()
+            elif field_number == 56 and tag == 448:
+                message['l'] = reader.bool()
+            elif field_number == 57 and tag == 456:
+                message['G7'] = long_to_number(reader.int64())
+            elif field_number == 58 and tag == 464:
+                message['preferVp9'] = reader.bool()
+            elif field_number == 59 and tag == 472:
+                message['qj'] = reader.int32()
+            elif field_number == 60 and tag == 480:
+                message['Hx'] = reader.int32()
+            elif field_number == 61 and tag == 488:
+                message['isPrefetch'] = reader.bool()
+            elif field_number == 62 and tag == 496:
+                message['sabrSupportQualityConstraints'] = reader.int32()
+            elif field_number == 63 and tag == 506:
+                message['sabrLicenseConstraint'] = reader.bytes()
+            elif field_number == 64 and tag == 512:
+                message['allowProximaLiveLatency'] = reader.int32()
+            elif field_number == 66 and tag == 528:
+                message['sabrForceProxima'] = reader.int32()
+            elif field_number == 67 and tag == 536:
+                message['Tqb'] = reader.int32()
+            elif field_number == 68 and tag == 544:
+                message['sabrForceMaxNetworkInterruptionDurationMs'] = long_to_number(reader.int64())
+            elif field_number == 69 and tag == 554:
+                message['audioTrackId'] = reader.string()
+            else:
+                if (tag & 7) == 4 or tag == 0:
+                    break
+                reader.skip(tag & 7)
+
+        return message
+
+def long_to_number(int64_value):
+    value = int(str(int64_value))
+    if value > (2 ** 53 - 1):
+        raise OverflowError("Value is larger than 9007199254740991")
+    if value < -(2 ** 53 - 1):
+        raise OverflowError("Value is smaller than -9007199254740991")
+    return value

--- a/pytubefix/sabr/video_streaming/client_abr_state.py
+++ b/pytubefix/sabr/video_streaming/client_abr_state.py
@@ -162,92 +162,136 @@ class ClientAbrState:
 
             if field_number == 13 and tag == 104:
                 message['timeSinceLastManualFormatSelectionMs'] = long_to_number(reader.int64())
+                continue
             elif field_number == 14 and tag == 112:
                 message['lastManualDirection'] = reader.sint32()
+                continue
             elif field_number == 16 and tag == 128:
                 message['lastManualSelectedResolution'] = reader.int32()
+                continue
             elif field_number == 17 and tag == 136:
                 message['detailedNetworkType'] = reader.int32()
+                continue
             elif field_number == 18 and tag == 144:
                 message['clientViewportWidth'] = reader.int32()
+                continue
             elif field_number == 19 and tag == 152:
                 message['clientViewportHeight'] = reader.int32()
+                continue
             elif field_number == 20 and tag == 160:
                 message['clientBitrateCapBytesPerSec'] = long_to_number(reader.int64())
+                continue
             elif field_number == 21 and tag == 168:
                 message['stickyResolution'] = reader.int32()
+                continue
             elif field_number == 22 and tag == 176:
                 message['clientViewportIsFlexible'] = reader.bool()
+                continue
             elif field_number == 23 and tag == 184:
                 message['bandwidthEstimate'] = long_to_number(reader.int64())
+                continue
             elif field_number == 24 and tag == 192:
                 message['minAudioQuality'] = reader.int32()
+                continue
             elif field_number == 25 and tag == 200:
                 message['maxAudioQuality'] = reader.int32()
+                continue
             elif field_number == 26 and tag == 208:
                 message['videoQualitySetting'] = reader.int32()
+                continue
             elif field_number == 27 and tag == 216:
                 message['audioRoute'] = reader.int32()
+                continue
             elif field_number == 28 and tag == 224:
                 message['playerTimeMs'] = long_to_number(reader.int64())
+                continue
             elif field_number == 29 and tag == 232:
                 message['timeSinceLastSeek'] = long_to_number(reader.int64())
+                continue
             elif field_number == 30 and tag == 240:
                 message['dataSaverMode'] = reader.bool()
+                continue
             elif field_number == 32 and tag == 256:
                 message['networkMeteredState'] = reader.int32()
+                continue
             elif field_number == 34 and tag == 272:
                 message['visibility'] = reader.int32()
+                continue
             elif field_number == 35 and tag == 285:
                 message['playbackRate'] = reader.float()
+                continue
             elif field_number == 36 and tag == 288:
                 message['elapsedWallTimeMs'] = long_to_number(reader.int64())
+                continue
             elif field_number == 38 and tag == 306:
                 message['mediaCapabilities'] = reader.bytes()
+                continue
             elif field_number == 39 and tag == 312:
                 message['timeSinceLastActionMs'] = long_to_number(reader.int64())
+                continue
             elif field_number == 40 and tag == 320:
                 message['enabledTrackTypesBitfield'] = reader.int32()
+                continue
             elif field_number == 43 and tag == 344:
                 message['maxPacingRate'] = reader.int32()
+                continue
             elif field_number == 44 and tag == 352:
                 message['playerState'] = long_to_number(reader.int64())
+                continue
             elif field_number == 46 and tag == 368:
                 message['drcEnabled'] = reader.bool()
+                continue
             elif field_number == 48 and tag == 384:
                 message['Jda'] = reader.int32()
+                continue
             elif field_number == 50 and tag == 400:
                 message['qw'] = reader.int32()
+                continue
             elif field_number == 51 and tag == 408:
                 message['Ky'] = reader.int32()
+                continue
             elif field_number == 54 and tag == 432:
                 message['sabrReportRequestCancellationInfo'] = reader.int32()
+                continue
             elif field_number == 56 and tag == 448:
                 message['l'] = reader.bool()
+                continue
             elif field_number == 57 and tag == 456:
                 message['G7'] = long_to_number(reader.int64())
+                continue
             elif field_number == 58 and tag == 464:
                 message['preferVp9'] = reader.bool()
+                continue
             elif field_number == 59 and tag == 472:
                 message['qj'] = reader.int32()
+                continue
             elif field_number == 60 and tag == 480:
                 message['Hx'] = reader.int32()
+                continue
             elif field_number == 61 and tag == 488:
                 message['isPrefetch'] = reader.bool()
+                continue
             elif field_number == 62 and tag == 496:
                 message['sabrSupportQualityConstraints'] = reader.int32()
+                continue
             elif field_number == 63 and tag == 506:
                 message['sabrLicenseConstraint'] = reader.bytes()
+                continue
             elif field_number == 64 and tag == 512:
                 message['allowProximaLiveLatency'] = reader.int32()
+                continue
             elif field_number == 66 and tag == 528:
                 message['sabrForceProxima'] = reader.int32()
+                continue
             elif field_number == 67 and tag == 536:
                 message['Tqb'] = reader.int32()
+                continue
             elif field_number == 68 and tag == 544:
                 message['sabrForceMaxNetworkInterruptionDurationMs'] = long_to_number(reader.int64())
+                continue
             elif field_number == 69 and tag == 554:
                 message['audioTrackId'] = reader.string()
+                continue
             else:
                 if (tag & 7) == 4 or tag == 0:
                     break

--- a/pytubefix/sabr/video_streaming/format_initialization_metadata.py
+++ b/pytubefix/sabr/video_streaming/format_initialization_metadata.py
@@ -1,0 +1,105 @@
+# All credits to https://github.com/LuanRT/googlevideo
+
+from pytubefix.sabr.proto import BinaryReader, BinaryWriter
+from pytubefix.sabr.common import FormatId, InitRange, IndexRange
+
+
+class FormatInitializationMetadata:
+    def __init__( self):
+        self.videoId = ""
+        self.formatId = None
+        self.endTimeMs = 0
+        self.endSegmentNumber = 0
+        self.mimeType = ""
+        self.initRange = None
+        self.indexRange = None
+        self.field8 = 0
+        self.durationMs = 0
+        self.field10 = 0
+
+    @staticmethod
+    def encode(message, writer=None):
+        if writer is None:
+            writer = BinaryWriter()
+        if message.videoId != "":
+            writer.uint32(10)
+            writer.string(message.videoId)
+        if message.formatId is not None:
+            writer.uint32(18)
+            FormatId.encode(message.formatId, writer.fork()).join()
+        if message.endTimeMs != 0:
+            writer.uint32(24)
+            writer.int32(message.endTimeMs)
+        if message.endSegmentNumber != 0:
+            writer.uint32(32)
+            writer.int64(message.endSegmentNumber)
+        if message.mimeType != "":
+            writer.uint32(42)
+            writer.string(message.mimeType)
+        if message.initRange is not None:
+            writer.uint32(50)
+            InitRange.encode(message.initRange, writer.fork()).join()
+        if message.indexRange is not None:
+            writer.uint32(58)
+            IndexRange.encode(message.indexRange, writer.fork()).join()
+        if message.field8 != 0:
+            writer.uint32(64)
+            writer.int32(message.field8)
+        if message.durationMs != 0:
+            writer.uint32(72)
+            writer.int32(message.durationMs)
+        if message.field10 != 0:
+            writer.uint32(80)
+            writer.int32(message.field10)
+        return writer
+
+    @staticmethod
+    def decode(input_data, length=None):
+        reader = input_data if isinstance(input_data, BinaryReader) else BinaryReader(input_data)
+        end = reader.len if length is None else reader.pos + length
+        message = FormatInitializationMetadata()
+        while reader.pos < end:
+            tag = reader.uint32()
+            field_no = tag >> 3
+            if field_no == 1 and tag == 10:
+                message.videoId = reader.string()
+                continue
+            elif field_no == 2 and tag == 18:
+                message.formatId = FormatId.decode(reader, reader.uint32())
+                continue
+            elif field_no == 3 and tag == 24:
+                message.endTimeMs = reader.int32()
+                continue
+            elif field_no == 4 and tag == 32:
+                message.endSegmentNumber = long_to_number(reader.int64())
+                continue
+            elif field_no == 5 and tag == 42:
+                message.mimeType = reader.string()
+                continue
+            elif field_no == 6 and tag == 50:
+                message.initRange = InitRange.decode(reader, reader.uint32())
+                continue
+            elif field_no == 7 and tag == 58:
+                message.indexRange = IndexRange.decode(reader, reader.uint32())
+                continue
+            elif field_no == 8 and tag == 64:
+                message.field8 = reader.int32()
+                continue
+            elif field_no == 9 and tag == 72:
+                message.durationMs = reader.int32()
+                continue
+            elif field_no == 10 and tag == 80:
+                message.field10 = reader.int32()
+                continue
+            if (tag & 7) == 4 or tag == 0:
+                break
+            reader.skip(tag & 7)
+        return message
+
+def long_to_number(int64_value):
+    value = int(str(int64_value))
+    if value > (2 ** 53 - 1):
+        raise OverflowError("Value is larger than 9007199254740991")
+    if value < -(2 ** 53 - 1):
+        raise OverflowError("Value is smaller than -9007199254740991")
+    return value

--- a/pytubefix/sabr/video_streaming/media_header.py
+++ b/pytubefix/sabr/video_streaming/media_header.py
@@ -1,0 +1,126 @@
+# All credits to https://github.com/LuanRT/googlevideo
+
+from enum import IntEnum
+from typing import Optional
+
+from pytubefix.sabr.common import FormatId
+from pytubefix.sabr.proto import BinaryReader, BinaryWriter
+from pytubefix.sabr.video_streaming.time_range import TimeRange
+
+
+class MediaHeaderCompressionAlgorithm(IntEnum):
+    UNKNOWN = 0
+    NONE = 1
+    GZIP = 2
+    UNRECOGNIZED = -1
+
+class MediaHeader:
+    def __init__(self):
+        self.headerId: int = 0
+        self.videoId: str = ""
+        self.itag: int = 0
+        self.lmt: int = 0
+        self.xtags: str = ""
+        self.startRange: int = 0
+        self.compressionAlgorithm: int = 0
+        self.isInitSeg: bool = False
+        self.sequenceNumber: int = 0
+        self.field10: int = 0
+        self.startMs: int = 0
+        self.durationMs: int = 0
+        self.formatId: Optional[FormatId] = None
+        self.contentLength: int = 0
+        self.timeRange = None
+
+    @staticmethod
+    def decode(reader, length: Optional[int] = None):
+        if not isinstance(reader, BinaryReader) :
+            reader = BinaryReader(reader)
+        end = reader.len if length is None else reader.pos + length
+        message = MediaHeader()
+        while reader.pos < end:
+            tag = reader.uint32()
+            field = tag >> 3
+
+            if field == 1 and tag == 8:
+                message.headerId = reader.uint32()
+            elif field == 2 and tag == 18:
+                message.videoId = reader.string()
+            elif field == 3 and tag == 24:
+                message.itag = reader.int32()
+            elif field == 4 and tag == 32:
+                message.lmt = long_to_number(reader.uint64())
+            elif field == 5 and tag == 42:
+                message.xtags = reader.string()
+            elif field == 6 and tag == 48:
+                message.startRange = long_to_number(reader.int64())
+            elif field == 7 and tag == 56:
+                message.compressionAlgorithm = reader.int32()
+            elif field == 8 and tag == 64:
+                message.isInitSeg = reader.bool()
+            elif field == 9 and tag == 72:
+                message.sequenceNumber = long_to_number(reader.int64())
+            elif field == 10 and tag == 80:
+                message.field10 = long_to_number(reader.int64())
+            elif field == 11 and tag == 88:
+                message.startMs = long_to_number(reader.int64())
+            elif field == 12 and tag == 96:
+                message.durationMs = long_to_number(reader.int64())
+            elif field == 13 and tag == 106:
+                length = reader.uint32()
+                message.formatId = FormatId.decode(reader, length)
+            elif field == 14 and tag == 112:
+                message.contentLength = long_to_number(reader.int64())
+            elif field == 15 and tag == 122:
+                length = reader.uint32()
+                message.timeRange = TimeRange.decode(reader, length)
+            elif (tag & 7) == 4 or tag == 0:
+                break
+            else:
+                reader.skip(tag & 7)
+        return message
+
+    def encode(self, writer: Optional[BinaryWriter] = None) -> BinaryWriter:
+        writer = writer or BinaryWriter()
+
+        if self.headerId:
+            writer.uint32(8).uint32(self.headerId)
+        if self.videoId:
+            writer.uint32(18).string(self.videoId)
+        if self.itag:
+            writer.uint32(24).int32(self.itag)
+        if self.lmt:
+            writer.uint32(32).uint64(self.lmt)
+        if self.xtags:
+            writer.uint32(42).string(self.xtags)
+        if self.startRange:
+            writer.uint32(48).int64(self.startRange)
+        if self.compressionAlgorithm:
+            writer.uint32(56).int32(self.compressionAlgorithm)
+        if self.isInitSeg:
+            writer.uint32(64).bool(self.isInitSeg)
+        if self.sequenceNumber:
+            writer.uint32(72).int64(self.sequenceNumber)
+        if self.field10:
+            writer.uint32(80).int64(self.field10)
+        if self.startMs:
+            writer.uint32(88).int64(self.startMs)
+        if self.durationMs:
+            writer.uint32(96).int64(self.durationMs)
+        if self.formatId is not None:
+            writer.uint32(106).fork()
+            self.formatId.encode(writer).join()
+        if self.contentLength:
+            writer.uint32(112).int64(self.contentLength)
+        if self.timeRange is not None:
+            writer.uint32(122).fork()
+            self.timeRange.encode(writer).join()
+        return writer
+
+def long_to_number(int64_value):
+    value = int(str(int64_value))
+    if value > (2 ** 53 - 1):
+        raise OverflowError("Value is larger than 9007199254740991")
+    if value < -(2 ** 53 - 1):
+        raise OverflowError("Value is smaller than -9007199254740991")
+    return value

--- a/pytubefix/sabr/video_streaming/media_header.py
+++ b/pytubefix/sabr/video_streaming/media_header.py
@@ -37,77 +37,93 @@ class MediaHeader:
 
             if field == 1 and tag == 8:
                 message.headerId = reader.uint32()
+                continue
             elif field == 2 and tag == 18:
                 message.videoId = reader.string()
+                continue
             elif field == 3 and tag == 24:
                 message.itag = reader.int32()
+                continue
             elif field == 4 and tag == 32:
                 message.lmt = long_to_number(reader.uint64())
+                continue
             elif field == 5 and tag == 42:
                 message.xtags = reader.string()
+                continue
             elif field == 6 and tag == 48:
                 message.startRange = long_to_number(reader.int64())
+                continue
             elif field == 7 and tag == 56:
                 message.compressionAlgorithm = reader.int32()
+                continue
             elif field == 8 and tag == 64:
                 message.isInitSeg = reader.bool()
+                continue
             elif field == 9 and tag == 72:
                 message.sequenceNumber = long_to_number(reader.int64())
+                continue
             elif field == 10 and tag == 80:
                 message.field10 = long_to_number(reader.int64())
+                continue
             elif field == 11 and tag == 88:
                 message.startMs = long_to_number(reader.int64())
+                continue
             elif field == 12 and tag == 96:
                 message.durationMs = long_to_number(reader.int64())
+                continue
             elif field == 13 and tag == 106:
                 length = reader.uint32()
                 message.formatId = FormatId.decode(reader, length)
+                continue
             elif field == 14 and tag == 112:
                 message.contentLength = long_to_number(reader.int64())
+                continue
             elif field == 15 and tag == 122:
                 length = reader.uint32()
                 message.timeRange = TimeRange.decode(reader, length)
+                continue
             elif (tag & 7) == 4 or tag == 0:
                 break
             else:
                 reader.skip(tag & 7)
         return message
 
-    def encode(self, writer: Optional[BinaryWriter] = None) -> BinaryWriter:
-        writer = writer or BinaryWriter()
+    @staticmethod
+    def encode(message: dict, writer=None):
+        if writer is None:
+            writer = BinaryWriter()
 
-        if self.headerId:
-            writer.uint32(8).uint32(self.headerId)
-        if self.videoId:
-            writer.uint32(18).string(self.videoId)
-        if self.itag:
-            writer.uint32(24).int32(self.itag)
-        if self.lmt:
-            writer.uint32(32).uint64(self.lmt)
-        if self.xtags:
-            writer.uint32(42).string(self.xtags)
-        if self.startRange:
-            writer.uint32(48).int64(self.startRange)
-        if self.compressionAlgorithm:
-            writer.uint32(56).int32(self.compressionAlgorithm)
-        if self.isInitSeg:
-            writer.uint32(64).bool(self.isInitSeg)
-        if self.sequenceNumber:
-            writer.uint32(72).int64(self.sequenceNumber)
-        if self.field10:
-            writer.uint32(80).int64(self.field10)
-        if self.startMs:
-            writer.uint32(88).int64(self.startMs)
-        if self.durationMs:
-            writer.uint32(96).int64(self.durationMs)
-        if self.formatId is not None:
-            writer.uint32(106).fork()
-            self.formatId.encode(writer).join()
-        if self.contentLength:
-            writer.uint32(112).int64(self.contentLength)
-        if self.timeRange is not None:
-            writer.uint32(122).fork()
-            self.timeRange.encode(writer).join()
+        if message.get("headerId", 0):
+            writer.uint32(8).uint32(message["headerId"])
+        if message.get("videoId", ""):
+            writer.uint32(18).string(message["videoId"])
+        if message.get("itag", 0):
+            writer.uint32(24).int32(message["itag"])
+        if message.get("lmt", 0):
+            writer.uint32(32).uint64(message["lmt"])
+        if message.get("xtags", ""):
+            writer.uint32(42).string(message["xtags"])
+        if message.get("startRange", 0):
+            writer.uint32(48).int64(message["startRange"])
+        if message.get("compressionAlgorithm", 0):
+            writer.uint32(56).int32(message["compressionAlgorithm"])
+        if message.get("isInitSeg", False):
+            writer.uint32(64).bool(message["isInitSeg"])
+        if message.get("sequenceNumber", 0):
+            writer.uint32(72).int64(message["sequenceNumber"])
+        if message.get("field10", 0):
+            writer.uint32(80).int64(message["field10"])
+        if message.get("startMs", 0):
+            writer.uint32(88).int64(message["startMs"])
+        if message.get("durationMs", 0):
+            writer.uint32(96).int64(message["durationMs"])
+        if message.get("formatId", 0):
+            FormatId.encode(message["formatId"], writer.uint32(106).fork()).join()
+        if message.get("contentLength", 0):
+            writer.uint32(112).int64(message["contentLength"])
+        if message.get("timeRange", 0):
+            TimeRange.encode(message["timeRange"], writer.uint32(122).fork()).join()
+
         return writer
 
 def long_to_number(int64_value):

--- a/pytubefix/sabr/video_streaming/media_header.py
+++ b/pytubefix/sabr/video_streaming/media_header.py
@@ -1,18 +1,11 @@
 # All credits to https://github.com/LuanRT/googlevideo
 
-from enum import IntEnum
 from typing import Optional
 
 from pytubefix.sabr.common import FormatId
 from pytubefix.sabr.proto import BinaryReader, BinaryWriter
 from pytubefix.sabr.video_streaming.time_range import TimeRange
 
-
-class MediaHeaderCompressionAlgorithm(IntEnum):
-    UNKNOWN = 0
-    NONE = 1
-    GZIP = 2
-    UNRECOGNIZED = -1
 
 class MediaHeader:
     def __init__(self):
@@ -30,7 +23,7 @@ class MediaHeader:
         self.durationMs: int = 0
         self.formatId: Optional[FormatId] = None
         self.contentLength: int = 0
-        self.timeRange = None
+        self.timeRange: Optional[TimeRange] = None
 
     @staticmethod
     def decode(reader, length: Optional[int] = None):

--- a/pytubefix/sabr/video_streaming/next_request_policy.py
+++ b/pytubefix/sabr/video_streaming/next_request_policy.py
@@ -1,0 +1,62 @@
+# All credits to https://github.com/LuanRT/googlevideo
+
+from pytubefix.sabr.proto import BinaryWriter, BinaryReader
+from pytubefix.sabr.video_streaming.playback_cookie import PlaybackCookie
+
+
+class NextRequestPolicy:
+    def __init__(self):
+        self.targetAudioReadaheadMs = 0
+        self.targetVideoReadaheadMs = 0
+        self.backoffTimeMs = 0
+        self.playbackCookie = None
+        self.videoId = ""
+
+    @staticmethod
+    def encode(message: dict, writer=None):
+        if writer is None:
+            writer = BinaryWriter()
+
+        if message.get("targetAudioReadaheadMs", 0) != 0:
+            writer.uint32(8).int32(message["targetAudioReadaheadMs"])
+
+        if message.get("targetVideoReadaheadMs", 0) != 0:
+            writer.uint32(16).int32(message["targetVideoReadaheadMs"])
+
+        if message.get("backoffTimeMs", 0) != 0:
+            writer.uint32(32).int32(message["backoffTimeMs"])
+
+        if message.get("playbackCookie") is not None:
+            PlaybackCookie.encode(message["playbackCookie"], writer.uint32(58).fork()).join()
+
+        if message.get("videoId", "") != "":
+            writer.uint32(66).string(message["videoId"])
+
+        return writer
+
+    @staticmethod
+    def decode(data, length=None):
+        reader = data if isinstance(data, BinaryReader) else BinaryReader(data)
+        end = reader.len if length is None else reader.pos + length
+        message = NextRequestPolicy
+
+        while reader.pos < end:
+            tag = reader.uint32()
+            field = tag >> 3
+
+            if field == 1 and tag == 8:
+                message.targetAudioReadaheadMs = reader.int32()
+            elif field == 2 and tag == 16:
+                message.targetVideoReadaheadMs = reader.int32()
+            elif field == 4 and tag == 32:
+                message.backoffTimeMs = reader.int32()
+            elif field == 7 and tag == 58:
+                message.playbackCookie = PlaybackCookie.decode(reader, reader.uint32())
+            elif field == 8 and tag == 66:
+                message.videoId = reader.string()
+            elif (tag & 7) == 4 or tag == 0:
+                break
+            else:
+                reader.skip(tag & 7)
+
+        return message

--- a/pytubefix/sabr/video_streaming/next_request_policy.py
+++ b/pytubefix/sabr/video_streaming/next_request_policy.py
@@ -46,14 +46,19 @@ class NextRequestPolicy:
 
             if field == 1 and tag == 8:
                 message.targetAudioReadaheadMs = reader.int32()
+                continue
             elif field == 2 and tag == 16:
                 message.targetVideoReadaheadMs = reader.int32()
+                continue
             elif field == 4 and tag == 32:
                 message.backoffTimeMs = reader.int32()
+                continue
             elif field == 7 and tag == 58:
                 message.playbackCookie = PlaybackCookie.decode(reader, reader.uint32())
+                continue
             elif field == 8 and tag == 66:
                 message.videoId = reader.string()
+                continue
             elif (tag & 7) == 4 or tag == 0:
                 break
             else:

--- a/pytubefix/sabr/video_streaming/playback_cookie.py
+++ b/pytubefix/sabr/video_streaming/playback_cookie.py
@@ -1,0 +1,59 @@
+# All credits to https://github.com/LuanRT/googlevideo
+
+from pytubefix.sabr.common import FormatId
+from pytubefix.sabr.proto import BinaryReader, BinaryWriter
+
+
+class PlaybackCookie:
+    @staticmethod
+    def create_base():
+        return {
+            "field1": 0,
+            "field2": 0,
+            "videoFmt": None,
+            "audioFmt": None
+        }
+
+    @staticmethod
+    def encode(message: dict, writer=None):
+        if writer is None:
+            writer = BinaryWriter()
+
+        if message.get("field1", 0) != 0:
+            writer.uint32(8).int32(message["field1"])
+
+        if message.get("field2", 0) != 0:
+            writer.uint32(16).int32(message["field2"])
+
+        if message.get("videoFmt") is not None:
+            FormatId.encode(message["videoFmt"], writer.uint32(58).fork()).join()
+
+        if message.get("audioFmt") is not None:
+            FormatId.encode(message["audioFmt"], writer.uint32(66).fork()).join()
+
+        return writer
+
+    @staticmethod
+    def decode(data, length=None):
+        reader = data if isinstance(data, BinaryReader) else BinaryReader(data)
+        end = reader.len if length is None else reader.pos + length
+        message = PlaybackCookie.create_base()
+
+        while reader.pos < end:
+            tag = reader.uint32()
+            field = tag >> 3
+
+            if field == 1 and tag == 8:
+                message["field1"] = reader.int32()
+            elif field == 2 and tag == 16:
+                message["field2"] = reader.int32()
+            elif field == 7 and tag == 58:
+                message["videoFmt"] = FormatId.decode(reader, reader.uint32())
+            elif field == 8 and tag == 66:
+                message["audioFmt"] = FormatId.decode(reader, reader.uint32())
+            elif (tag & 7) == 4 or tag == 0:
+                break
+            else:
+                reader.skip(tag & 7)
+
+        return message

--- a/pytubefix/sabr/video_streaming/playback_cookie.py
+++ b/pytubefix/sabr/video_streaming/playback_cookie.py
@@ -45,12 +45,16 @@ class PlaybackCookie:
 
             if field == 1 and tag == 8:
                 message["field1"] = reader.int32()
+                continue
             elif field == 2 and tag == 16:
                 message["field2"] = reader.int32()
+                continue
             elif field == 7 and tag == 58:
                 message["videoFmt"] = FormatId.decode(reader, reader.uint32())
+                continue
             elif field == 8 and tag == 66:
                 message["audioFmt"] = FormatId.decode(reader, reader.uint32())
+                continue
             elif (tag & 7) == 4 or tag == 0:
                 break
             else:

--- a/pytubefix/sabr/video_streaming/sabr_error.py
+++ b/pytubefix/sabr/video_streaming/sabr_error.py
@@ -1,0 +1,46 @@
+# All credits to https://github.com/LuanRT/googlevideo
+
+from pytubefix.sabr.proto import BinaryWriter, BinaryReader
+
+
+class SabrError:
+
+    def __init__(self):
+        self.type = ""
+        self.code = 0
+
+    @staticmethod
+    def encode(message: dict, writer=None):
+        if writer is None:
+            writer = BinaryWriter()
+
+        if message.get("type") not in (None, ""):
+            writer.uint32(10).string(message["type"])
+        if message.get("code") not in (None, 0):
+            writer.uint32(16).int32(message["code"])
+
+        return writer
+
+    @staticmethod
+    def decode(input_data, length=None):
+        reader = input_data if isinstance(input_data, BinaryReader) else BinaryReader(input_data)
+        end = reader.len if length is None else reader.pos + length
+
+        message = SabrError()
+
+        while reader.pos < end:
+            tag = reader.uint32()
+            field_number = tag >> 3
+
+            if field_number == 1 and tag == 10:
+                message.type = reader.string()
+                continue
+            if field_number == 2 and tag == 16:
+                message.code = reader.int32()
+                continue
+
+            if (tag & 7) == 4 or tag == 0:
+                break
+            reader.skip(tag & 7)
+
+        return message

--- a/pytubefix/sabr/video_streaming/sabr_redirect.py
+++ b/pytubefix/sabr/video_streaming/sabr_redirect.py
@@ -1,0 +1,41 @@
+# All credits to https://github.com/LuanRT/googlevideo
+
+from pytubefix.sabr.proto import BinaryReader, BinaryWriter
+
+
+class SabrRedirect:
+
+    def __init__(self):
+        self.url = ""
+
+    @staticmethod
+    def encode(message: dict, writer=None):
+        if writer is None:
+            writer = BinaryWriter()
+
+        if message.get("url") not in (None, ""):
+            writer.uint32(10).string(message["url"])
+
+        return writer
+
+    @staticmethod
+    def decode(input_data, length=None):
+        reader = input_data if isinstance(input_data, BinaryReader) else BinaryReader(input_data)
+        end = reader.len if length is None else reader.pos + length
+
+        message = SabrRedirect
+
+        while reader.pos < end:
+            tag = reader.uint32()
+            field_number = tag >> 3
+
+            if field_number == 1 and tag == 10:
+                message.url = reader.string()
+                continue
+
+            if (tag & 7) == 4 or tag == 0:
+                break
+
+            reader.skip(tag & 7)
+
+        return message

--- a/pytubefix/sabr/video_streaming/stream_protection_status.py
+++ b/pytubefix/sabr/video_streaming/stream_protection_status.py
@@ -1,0 +1,40 @@
+# All credits to https://github.com/LuanRT/googlevideo
+
+from pytubefix.sabr.proto import BinaryReader, BinaryWriter
+
+
+class StreamProtectionStatus:
+    def __init__(self, status=0, field2=0):
+        self.status = status
+        self.field2 = field2
+
+    @staticmethod
+    def encode(message, writer=None):
+        if writer is None:
+            writer = BinaryWriter()
+        if message.status != 0:
+            writer.uint32(8)
+            writer.int32(message.status)
+        if message.field2 != 0:
+            writer.uint32(16)
+            writer.int32(message.field2)
+        return writer
+
+    @staticmethod
+    def decode(input_data, length=None):
+        reader = input_data if isinstance(input_data, BinaryReader) else BinaryReader(input_data)
+        end = reader.len if length is None else reader.pos + length
+        message = StreamProtectionStatus()
+        while reader.pos < end:
+            tag = reader.uint32()
+            field_no = tag >> 3
+            if field_no == 1 and tag == 8:
+                message.status = reader.int32()
+                continue
+            elif field_no == 2 and tag == 16:
+                message.field2 = reader.int32()
+                continue
+            if (tag & 7) == 4 or tag == 0:
+                break
+            reader.skip(tag & 7)
+        return message

--- a/pytubefix/sabr/video_streaming/stream_protection_status.py
+++ b/pytubefix/sabr/video_streaming/stream_protection_status.py
@@ -4,20 +4,21 @@ from pytubefix.sabr.proto import BinaryReader, BinaryWriter
 
 
 class StreamProtectionStatus:
-    def __init__(self, status=0, field2=0):
-        self.status = status
-        self.field2 = field2
+    def __init__(self):
+        self.status = None
+        self.field2 = None
 
     @staticmethod
-    def encode(message, writer=None):
+    def encode(message: dict, writer=None):
         if writer is None:
             writer = BinaryWriter()
-        if message.status != 0:
+
+        if message.get("status", 0) != 0:
             writer.uint32(8)
-            writer.int32(message.status)
-        if message.field2 != 0:
+            writer.int32(message["status"])
+        if message.get("field2") != 0:
             writer.uint32(16)
-            writer.int32(message.field2)
+            writer.int32(message["field2"])
         return writer
 
     @staticmethod
@@ -25,6 +26,7 @@ class StreamProtectionStatus:
         reader = input_data if isinstance(input_data, BinaryReader) else BinaryReader(input_data)
         end = reader.len if length is None else reader.pos + length
         message = StreamProtectionStatus()
+
         while reader.pos < end:
             tag = reader.uint32()
             field_no = tag >> 3

--- a/pytubefix/sabr/video_streaming/streamer_context.py
+++ b/pytubefix/sabr/video_streaming/streamer_context.py
@@ -1,0 +1,337 @@
+# All credits to https://github.com/LuanRT/googlevideo
+
+from pytubefix.sabr.proto import BinaryWriter, BinaryReader
+
+
+class StreamerContext_ClientInfo:
+
+    def __init__(self):
+        self.deviceMake = "",
+        self.deviceModel = "",
+        self.clientName = 0,
+        self.clientVersion = "",
+        self.osName = "",
+        self.osVersion = "",
+        self.acceptLanguage = "",
+        self.acceptRegion = "",
+        self.screenWidthPoints = 0,
+        self.screenHeightPoints = 0,
+        self.screenWidthInches = 0.0,
+        self.screenHeightInches = 0.0,
+        self.screenPixelDensity = 0,
+        self.clientFormFactor = 0,
+        self.gmscoreVersionCode = 0,
+        self.windowWidthPoints = 0,
+        self.windowHeightPoints = 0,
+        self.androidSdkVersion = 0,
+        self.screenDensityFloat = 0.0,
+        self.utcOffsetMinutes = 0,
+        self.timeZone = "",
+        self.chipset = "",
+        self.glDeviceInfo = None,
+
+    @staticmethod
+    def encode(message: dict, writer=None):
+        if writer is None:
+            writer = BinaryWriter()
+
+        if message.get("deviceMake", "") != "":
+            writer.uint32(98).string(message["deviceMake"])
+        if message.get("deviceModel", "") != "":
+            writer.uint32(106).string(message["deviceModel"])
+        if message.get("clientName", 0) != 0:
+            writer.uint32(128).int32(message["clientName"])
+        if message.get("clientVersion", "") != "":
+            writer.uint32(138).string(message["clientVersion"])
+        if message.get("osName", "") != "":
+            writer.uint32(146).string(message["osName"])
+        if message.get("osVersion", "") != "":
+            writer.uint32(154).string(message["osVersion"])
+        if message.get("acceptLanguage", "") != "":
+            writer.uint32(170).string(message["acceptLanguage"])
+        if message.get("acceptRegion", "") != "":
+            writer.uint32(178).string(message["acceptRegion"])
+        if message.get("screenWidthPoints", 0) != 0:
+            writer.uint32(296).int32(message["screenWidthPoints"])
+        if message.get("screenHeightPoints", 0) != 0:
+            writer.uint32(304).int32(message["screenHeightPoints"])
+        if message.get("screenWidthInches", 0) != 0:
+            writer.uint32(317).float(message["screenWidthInches"])
+        if message.get("screenHeightInches", 0) != 0:
+            writer.uint32(325).float(message["screenHeightInches"])
+        if message.get("screenPixelDensity", 0) != 0:
+            writer.uint32(328).int32(message["screenPixelDensity"])
+        if message.get("clientFormFactor", 0) != 0:
+            writer.uint32(368).int32(message["clientFormFactor"])
+        if message.get("gmscoreVersionCode", 0) != 0:
+            writer.uint32(400).int32(message["gmscoreVersionCode"])
+        if message.get("windowWidthPoints", 0) != 0:
+            writer.uint32(440).int32(message["windowWidthPoints"])
+        if message.get("windowHeightPoints", 0) != 0:
+            writer.uint32(448).int32(message["windowHeightPoints"])
+        if message.get("androidSdkVersion", 0) != 0:
+            writer.uint32(512).int32(message["androidSdkVersion"])
+        if message.get("screenDensityFloat", 0) != 0:
+            writer.uint32(525).float(message["screenDensityFloat"])
+        if message.get("utcOffsetMinutes", 0) != 0:
+            writer.uint32(536).int64(message["utcOffsetMinutes"])
+        if message.get("timeZone", "") != "":
+            writer.uint32(642).string(message["timeZone"])
+        if message.get("chipset", "") != "":
+            writer.uint32(738).string(message["chipset"])
+
+        return writer
+
+    @staticmethod
+    def decode_streamer_context_client_info(input_data, length=None):
+        reader = input_data if isinstance(input_data, BinaryReader) else BinaryReader(input_data)
+        end = reader.len if length is None else reader.pos + length
+        message = StreamerContext_ClientInfo()
+
+        while reader.pos < end:
+            tag = reader.uint32()
+            field_number = tag >> 3
+
+            if field_number == 12 and tag == 98:
+                message.deviceMake = reader.string()
+            elif field_number == 13 and tag == 106:
+                message.deviceModel = reader.string()
+            elif field_number == 16 and tag == 128:
+                message.clientName = reader.int32()
+            elif field_number == 17 and tag == 138:
+                message.clientVersion = reader.string()
+            elif field_number == 18 and tag == 146:
+                message.osName = reader.string()
+            elif field_number == 19 and tag == 154:
+                message.osVersion = reader.string()
+            elif field_number == 21 and tag == 170:
+                message.acceptLanguage = reader.string()
+            elif field_number == 22 and tag == 178:
+                message.acceptRegion = reader.string()
+            elif field_number == 37 and tag == 296:
+                message.screenWidthPoints = reader.int32()
+            elif field_number == 38 and tag == 304:
+                message.screenHeightPoints = reader.int32()
+            elif field_number == 39 and tag == 317:
+                message.screenWidthInches = reader.float()
+            elif field_number == 40 and tag == 325:
+                message.screenHeightInches = reader.float()
+            elif field_number == 41 and tag == 328:
+                message.screenPixelDensity = reader.int32()
+            elif field_number == 46 and tag == 368:
+                message.clientFormFactor = reader.int32()
+            elif field_number == 50 and tag == 400:
+                message.gmscoreVersionCode = reader.int32()
+            elif field_number == 55 and tag == 440:
+                message.windowWidthPoints = reader.int32()
+            elif field_number == 56 and tag == 448:
+                message.windowHeightPoints = reader.int32()
+            elif field_number == 64 and tag == 512:
+                message.androidSdkVersion = reader.int32()
+            elif field_number == 65 and tag == 525:
+                message.screenDensityFloat = reader.float()
+            elif field_number == 67 and tag == 536:
+                message.utcOffsetMinutes = long_to_number(reader.int64())
+            elif field_number == 80 and tag == 642:
+                message.timeZone = reader.string()
+            elif field_number == 92 and tag == 738:
+                message.chipset = reader.string()
+            else:
+                if (tag & 7) == 4 or tag == 0:
+                    break
+                reader.skip(tag & 7)
+
+        return message
+
+
+class StreamerContext_Fqa:
+    @staticmethod
+    def encode(message: dict, writer=None):
+        if writer is None:
+            writer = BinaryWriter()
+
+        if message.get("type", 0) != 0:
+            writer.uint32(8).int32(message["type"])
+        if message.get("value"):
+            writer.uint32(18).bytes(message["value"])
+
+        return writer
+
+class StreamerContext_Gqa:
+    @staticmethod
+    def encode(message: dict, writer=None):
+        if writer is None:
+            writer = BinaryWriter()
+
+        if message.get("field1"):
+            writer.uint32(10).bytes(message["field1"])
+        if message.get("field2") is not None:
+            StreamerContext_Gqa_Hqa.encode(message["field2"], writer.uint32(18).fork()).join()
+
+        return writer
+
+
+class StreamerContext_Gqa_Hqa:
+    @staticmethod
+    def encode(message: dict, writer=None):
+        if writer is None:
+            writer = BinaryWriter()
+
+        if message.get("code", 0) != 0:
+            writer.uint32(8).int32(message["code"])
+        if message.get("message", "") != "":
+            writer.uint32(18).string(message["message"])
+
+        return writer
+
+
+class StreamerContext:
+
+    def __init__(self):
+        self.deviceMake = "",
+        self.deviceModel = "",
+        self.clientName = 0,
+        self.clientVersion = "",
+        self.osName = "",
+        self.osVersion = "",
+        self.acceptLanguage = "",
+        self.acceptRegion = "",
+        self.screenWidthPoints = 0,
+        self.screenHeightPoints = 0,
+        self.screenWidthInches = 0.0,
+        self.screenHeightInches = 0.0,
+        self.screenPixelDensity = 0,
+        self.clientFormFactor = 0,
+        self.gmscoreVersionCode = 0,
+        self.windowWidthPoints = 0,
+        self.windowHeightPoints = 0,
+        self.androidSdkVersion = 0,
+        self.screenDensityFloat = 0.0,
+        self.utcOffsetMinutes = 0,
+        self.timeZone = "",
+        self.chipset = "",
+        self.glDeviceInfo = None,
+
+    @staticmethod
+    def encode(message: dict, writer=None):
+        if writer is None:
+            writer = BinaryWriter()
+
+        if message.get("clientInfo") is not None:
+            StreamerContext_ClientInfo.encode(message["clientInfo"], writer.uint32(10).fork()).join()
+
+        if message.get("poToken"):
+            writer.uint32(18).bytes(message["poToken"])
+
+        if message.get("playbackCookie"):
+            writer.uint32(26).bytes(message["playbackCookie"])
+
+        if message.get("gp"):
+            writer.uint32(34).bytes(message["gp"])
+
+        for v in message.get("field5", []):
+            StreamerContext_Fqa.encode(v, writer.uint32(42).fork()).join()
+
+        writer.uint32(50).fork()
+        for v in message.get("field6", []):
+            writer.int32(v)
+        writer.join()
+
+        if message.get("field7", "") != "":
+            writer.uint32(58).string(message["field7"])
+
+        if message.get("field8") is not None:
+            StreamerContext_Gqa.encode(message["field8"], writer.uint32(66).fork()).join()
+
+        return writer
+
+    @staticmethod
+    def decode_streamer_context_client_info(input_data, length=None):
+        reader = input_data if isinstance(input_data, BinaryReader) else BinaryReader(input_data)
+        end = reader.len if length is None else reader.pos + length
+        message = StreamerContext()
+
+        while reader.pos < end:
+            tag = reader.uint32()
+            field_number = tag >> 3
+
+            if field_number == 12 and tag == 98:
+                message.deviceMake = reader.string()
+                continue
+            if field_number == 13 and tag == 106:
+                message.deviceModel = reader.string()
+                continue
+            if field_number == 16 and tag == 128:
+                message.clientName = reader.int32()
+                continue
+            if field_number == 17 and tag == 138:
+                message.clientVersion = reader.string()
+                continue
+            if field_number == 18 and tag == 146:
+                message.osName = reader.string()
+                continue
+            if field_number == 19 and tag == 154:
+                message.osVersion = reader.string()
+                continue
+            if field_number == 21 and tag == 170:
+                message.acceptLanguage = reader.string()
+                continue
+            if field_number == 22 and tag == 178:
+                message.acceptRegion = reader.string()
+                continue
+            if field_number == 37 and tag == 296:
+                message.screenWidthPoints = reader.int32()
+                continue
+            if field_number == 38 and tag == 304:
+                message.screenHeightPoints = reader.int32()
+                continue
+            if field_number == 39 and tag == 317:
+                message.screenWidthInches = reader.float()
+                continue
+            if field_number == 40 and tag == 325:
+                message.screenHeightInches = reader.float()
+                continue
+            if field_number == 41 and tag == 328:
+                message.screenPixelDensity = reader.int32()
+                continue
+            if field_number == 46 and tag == 368:
+                message.clientFormFactor = reader.int32()
+                continue
+            if field_number == 50 and tag == 400:
+                message.gmscoreVersionCode = reader.int32()
+                continue
+            if field_number == 55 and tag == 440:
+                message.windowWidthPoints = reader.int32()
+                continue
+            if field_number == 56 and tag == 448:
+                message.windowHeightPoints = reader.int32()
+                continue
+            if field_number == 64 and tag == 512:
+                message.androidSdkVersion = reader.int32()
+                continue
+            if field_number == 65 and tag == 525:
+                message.screenDensityFloat = reader.float()
+                continue
+            if field_number == 67 and tag == 536:
+                message.utcOffsetMinutes = long_to_number(reader.int64())
+                continue
+            if field_number == 80 and tag == 642:
+                message.timeZone = reader.string()
+                continue
+            if field_number == 92 and tag == 738:
+                message.chipset = reader.string()
+                continue
+
+            if (tag & 7) == 4 or tag == 0:
+                break
+            reader.skip(tag & 7)
+
+        return message
+
+def long_to_number(int64_value):
+    value = int(str(int64_value))
+    if value > (2 ** 53 - 1):
+        raise OverflowError("Value is larger than 9007199254740991")
+    if value < -(2 ** 53 - 1):
+        raise OverflowError("Value is smaller than -9007199254740991")
+    return value

--- a/pytubefix/sabr/video_streaming/streamer_context.py
+++ b/pytubefix/sabr/video_streaming/streamer_context.py
@@ -1,89 +1,91 @@
 # All credits to https://github.com/LuanRT/googlevideo
 
 from pytubefix.sabr.proto import BinaryWriter, BinaryReader
+from pytubefix.sabr.video_streaming.playback_cookie import PlaybackCookie
 
 
 class StreamerContext_ClientInfo:
 
     def __init__(self):
-        self.deviceMake = "",
-        self.deviceModel = "",
-        self.clientName = 0,
-        self.clientVersion = "",
-        self.osName = "",
-        self.osVersion = "",
-        self.acceptLanguage = "",
-        self.acceptRegion = "",
-        self.screenWidthPoints = 0,
-        self.screenHeightPoints = 0,
-        self.screenWidthInches = 0.0,
-        self.screenHeightInches = 0.0,
-        self.screenPixelDensity = 0,
-        self.clientFormFactor = 0,
-        self.gmscoreVersionCode = 0,
-        self.windowWidthPoints = 0,
-        self.windowHeightPoints = 0,
-        self.androidSdkVersion = 0,
-        self.screenDensityFloat = 0.0,
-        self.utcOffsetMinutes = 0,
-        self.timeZone = "",
-        self.chipset = "",
-        self.glDeviceInfo = None,
+        self.locale = None
+        self.deviceMake = None
+        self.deviceModel = None
+        self.clientName = None
+        self.clientVersion = None
+        self.osName = None
+        self.osVersion = None
+        self.acceptLanguage = None
+        self.acceptRegion = None
+        self.screenWidthPoints = None
+        self.screenHeightPoints = None
+        self.screenWidthInches = None
+        self.screenHeightInches = None
+        self.screenPixelDensity = None
+        self.clientFormFactor = None
+        self.gmscoreVersionCode = None
+        self.windowWidthPoints = None
+        self.windowHeightPoints = None
+        self.androidSdkVersion = None
+        self.screenDensityFloat = None
+        self.utcOffsetMinutes = None
+        self.timeZone = None
+        self.chipset = None
+        self.glDeviceInfo = None
 
     @staticmethod
     def encode(message: dict, writer=None):
         if writer is None:
             writer = BinaryWriter()
 
-        if message.get("deviceMake", "") != "":
+        if message.get("deviceMake", ""):
             writer.uint32(98).string(message["deviceMake"])
-        if message.get("deviceModel", "") != "":
+        if message.get("deviceModel", "") :
             writer.uint32(106).string(message["deviceModel"])
-        if message.get("clientName", 0) != 0:
+        if message.get("clientName", 0):
             writer.uint32(128).int32(message["clientName"])
-        if message.get("clientVersion", "") != "":
+        if message.get("clientVersion", ""):
             writer.uint32(138).string(message["clientVersion"])
-        if message.get("osName", "") != "":
+        if message.get("osName", ""):
             writer.uint32(146).string(message["osName"])
-        if message.get("osVersion", "") != "":
+        if message.get("osVersion", ""):
             writer.uint32(154).string(message["osVersion"])
-        if message.get("acceptLanguage", "") != "":
+        if message.get("acceptLanguage", ""):
             writer.uint32(170).string(message["acceptLanguage"])
-        if message.get("acceptRegion", "") != "":
+        if message.get("acceptRegion", ""):
             writer.uint32(178).string(message["acceptRegion"])
-        if message.get("screenWidthPoints", 0) != 0:
+        if message.get("screenWidthPoints", 0):
             writer.uint32(296).int32(message["screenWidthPoints"])
-        if message.get("screenHeightPoints", 0) != 0:
+        if message.get("screenHeightPoints", 0):
             writer.uint32(304).int32(message["screenHeightPoints"])
-        if message.get("screenWidthInches", 0) != 0:
+        if message.get("screenWidthInches", 0):
             writer.uint32(317).float(message["screenWidthInches"])
-        if message.get("screenHeightInches", 0) != 0:
+        if message.get("screenHeightInches", 0):
             writer.uint32(325).float(message["screenHeightInches"])
-        if message.get("screenPixelDensity", 0) != 0:
+        if message.get("screenPixelDensity", 0):
             writer.uint32(328).int32(message["screenPixelDensity"])
-        if message.get("clientFormFactor", 0) != 0:
+        if message.get("clientFormFactor", 0):
             writer.uint32(368).int32(message["clientFormFactor"])
-        if message.get("gmscoreVersionCode", 0) != 0:
+        if message.get("gmscoreVersionCode", 0):
             writer.uint32(400).int32(message["gmscoreVersionCode"])
-        if message.get("windowWidthPoints", 0) != 0:
+        if message.get("windowWidthPoints", 0):
             writer.uint32(440).int32(message["windowWidthPoints"])
-        if message.get("windowHeightPoints", 0) != 0:
+        if message.get("windowHeightPoints", 0):
             writer.uint32(448).int32(message["windowHeightPoints"])
-        if message.get("androidSdkVersion", 0) != 0:
+        if message.get("androidSdkVersion", 0):
             writer.uint32(512).int32(message["androidSdkVersion"])
-        if message.get("screenDensityFloat", 0) != 0:
+        if message.get("screenDensityFloat", 0):
             writer.uint32(525).float(message["screenDensityFloat"])
-        if message.get("utcOffsetMinutes", 0) != 0:
+        if message.get("utcOffsetMinutes", 0):
             writer.uint32(536).int64(message["utcOffsetMinutes"])
-        if message.get("timeZone", "") != "":
+        if message.get("timeZone", ""):
             writer.uint32(642).string(message["timeZone"])
-        if message.get("chipset", "") != "":
+        if message.get("chipset", ""):
             writer.uint32(738).string(message["chipset"])
 
         return writer
 
     @staticmethod
-    def decode_streamer_context_client_info(input_data, length=None):
+    def decode(input_data, length=None):
         reader = input_data if isinstance(input_data, BinaryReader) else BinaryReader(input_data)
         end = reader.len if length is None else reader.pos + length
         message = StreamerContext_ClientInfo()
@@ -92,50 +94,77 @@ class StreamerContext_ClientInfo:
             tag = reader.uint32()
             field_number = tag >> 3
 
+            if field_number == 1 and tag == 10:
+                message.locale = reader.string()
+                continue
             if field_number == 12 and tag == 98:
                 message.deviceMake = reader.string()
+                continue
             elif field_number == 13 and tag == 106:
                 message.deviceModel = reader.string()
+                continue
             elif field_number == 16 and tag == 128:
                 message.clientName = reader.int32()
+                continue
             elif field_number == 17 and tag == 138:
                 message.clientVersion = reader.string()
+                continue
             elif field_number == 18 and tag == 146:
                 message.osName = reader.string()
+                continue
             elif field_number == 19 and tag == 154:
                 message.osVersion = reader.string()
+                continue
             elif field_number == 21 and tag == 170:
                 message.acceptLanguage = reader.string()
+                continue
             elif field_number == 22 and tag == 178:
                 message.acceptRegion = reader.string()
+                continue
             elif field_number == 37 and tag == 296:
                 message.screenWidthPoints = reader.int32()
+                continue
             elif field_number == 38 and tag == 304:
                 message.screenHeightPoints = reader.int32()
+                continue
             elif field_number == 39 and tag == 317:
                 message.screenWidthInches = reader.float()
+                continue
             elif field_number == 40 and tag == 325:
                 message.screenHeightInches = reader.float()
+                continue
             elif field_number == 41 and tag == 328:
                 message.screenPixelDensity = reader.int32()
+                continue
             elif field_number == 46 and tag == 368:
                 message.clientFormFactor = reader.int32()
+                continue
             elif field_number == 50 and tag == 400:
                 message.gmscoreVersionCode = reader.int32()
+                continue
             elif field_number == 55 and tag == 440:
                 message.windowWidthPoints = reader.int32()
+                continue
             elif field_number == 56 and tag == 448:
                 message.windowHeightPoints = reader.int32()
+                continue
             elif field_number == 64 and tag == 512:
                 message.androidSdkVersion = reader.int32()
+                continue
             elif field_number == 65 and tag == 525:
                 message.screenDensityFloat = reader.float()
+                continue
             elif field_number == 67 and tag == 536:
                 message.utcOffsetMinutes = long_to_number(reader.int64())
+                continue
             elif field_number == 80 and tag == 642:
                 message.timeZone = reader.string()
+                continue
             elif field_number == 92 and tag == 738:
                 message.chipset = reader.string()
+                continue
+            elif field_number == 102 and tag == 818:
+                message.glDeviceInfo = StreamerContext_GLDeviceInfo.decode(reader, reader.uint32())
             else:
                 if (tag & 7) == 4 or tag == 0:
                     break
@@ -144,73 +173,194 @@ class StreamerContext_ClientInfo:
         return message
 
 
-class StreamerContext_Fqa:
+class StreamerContext_GLDeviceInfo:
+
+    def __init__(self):
+        self.glRenderer = ""
+        self.glEsVersionMajor = 0
+        self.glEsVersionMinor = 0
+
     @staticmethod
     def encode(message: dict, writer=None):
         if writer is None:
             writer = BinaryWriter()
 
-        if message.get("type", 0) != 0:
+        if message.get("glRenderer", ""):
+            writer.uint32(10).string(message["glRenderer"])
+        if message.get("glEsVersionMajor", ""):
+            writer.uint32(16).int32(message["glEsVersionMajor"])
+        if message.get("glEsVersionMinor", ""):
+            writer.uint32(24).int32(message["glEsVersionMinor"])
+
+        return writer
+
+    @staticmethod
+    def decode(data, length=None):
+        reader = data if isinstance(data, BinaryReader) else BinaryReader(data)
+        end = reader.len if length is None else reader.pos + length
+        message = StreamerContext_GLDeviceInfo()
+
+        while reader.pos < end:
+            tag = reader.uint32()
+            field_number = tag >> 3
+
+            if field_number == 1 and tag == 10:
+                message.glRenderer = reader.string()
+                continue
+            elif field_number == 2 and tag == 16:
+                message.glEsVersionMajor = reader.int32()
+                continue
+            elif field_number == 3 and tag == 24:
+                message.glEsVersionMinor = reader.int32()
+                continue
+
+            elif (tag & 7) == 4 or tag == 0:
+                break
+            else:
+                reader.skip(tag & 7)
+
+        return message
+
+class StreamerContext_Fqa:
+
+    def __init__(self):
+        self.type = 0
+        self.value = None
+
+    @staticmethod
+    def encode(message: dict, writer=None):
+        if writer is None:
+            writer = BinaryWriter()
+
+        if message.get("type", 0):
             writer.uint32(8).int32(message["type"])
-        if message.get("value"):
+        if message.get("value", 0):
             writer.uint32(18).bytes(message["value"])
 
         return writer
 
+    @staticmethod
+    def decode(data, length=None):
+        reader = data if isinstance(data, BinaryReader) else BinaryReader(data)
+        end = reader.len if length is None else reader.pos + length
+        message = StreamerContext_Fqa()
+
+        while reader.pos < end:
+            tag = reader.uint32()
+            field_number = tag >> 3
+
+            if field_number == 1 and tag == 8:
+                message.type = reader.int32()
+                continue
+            elif field_number == 2 and tag == 18:
+                message.value = reader.int32()
+                continue
+
+            elif (tag & 7) == 4 or tag == 0:
+                break
+            else:
+                reader.skip(tag & 7)
+
+        return message
+
 class StreamerContext_Gqa:
+
+    def __init__(self):
+        self.field1 = None
+        self.field2 = None
+
     @staticmethod
     def encode(message: dict, writer=None):
         if writer is None:
             writer = BinaryWriter()
 
-        if message.get("field1"):
+        if message.get("field1", 0):
             writer.uint32(10).bytes(message["field1"])
-        if message.get("field2") is not None:
+        if message.get("field2", 0):
             StreamerContext_Gqa_Hqa.encode(message["field2"], writer.uint32(18).fork()).join()
 
         return writer
 
+    @staticmethod
+    def decode(data, length=None):
+        reader = data if isinstance(data, BinaryReader) else BinaryReader(data)
+        end = reader.len if length is None else reader.pos + length
+        message = StreamerContext_Gqa()
+
+        while reader.pos < end:
+            tag = reader.uint32()
+            field_number = tag >> 3
+
+            if field_number == 1 and tag == 10:
+                message.field1 = reader.bytes()
+                continue
+            elif field_number == 2 and tag == 18:
+                message.field2 = StreamerContext_Gqa_Hqa.decode(reader, reader.uint32())
+                continue
+
+            elif (tag & 7) == 4 or tag == 0:
+                break
+            else:
+                reader.skip(tag & 7)
+
+        return message
+
 
 class StreamerContext_Gqa_Hqa:
+
+    def __init__(self):
+        self.code = 0
+        self.message = ""
+
     @staticmethod
     def encode(message: dict, writer=None):
         if writer is None:
             writer = BinaryWriter()
 
-        if message.get("code", 0) != 0:
+        if message.get("code", 0):
             writer.uint32(8).int32(message["code"])
-        if message.get("message", "") != "":
+        if message.get("message", ""):
             writer.uint32(18).string(message["message"])
 
         return writer
+
+    @staticmethod
+    def decode(data, length=None):
+        reader = data if isinstance(data, BinaryReader) else BinaryReader(data)
+        end = reader.len if length is None else reader.pos + length
+        message = StreamerContext_Gqa_Hqa()
+
+        while reader.pos < end:
+            tag = reader.uint32()
+            field_number = tag >> 3
+
+            if field_number == 1 and tag == 8:
+                message.code = reader.int32()
+                continue
+            elif field_number == 2 and tag == 18:
+                message.message = reader.string()
+                continue
+
+            elif (tag & 7) == 4 or tag == 0:
+                break
+            else:
+                reader.skip(tag & 7)
+
+        return message
 
 
 class StreamerContext:
 
     def __init__(self):
-        self.deviceMake = "",
-        self.deviceModel = "",
-        self.clientName = 0,
-        self.clientVersion = "",
-        self.osName = "",
-        self.osVersion = "",
-        self.acceptLanguage = "",
-        self.acceptRegion = "",
-        self.screenWidthPoints = 0,
-        self.screenHeightPoints = 0,
-        self.screenWidthInches = 0.0,
-        self.screenHeightInches = 0.0,
-        self.screenPixelDensity = 0,
-        self.clientFormFactor = 0,
-        self.gmscoreVersionCode = 0,
-        self.windowWidthPoints = 0,
-        self.windowHeightPoints = 0,
-        self.androidSdkVersion = 0,
-        self.screenDensityFloat = 0.0,
-        self.utcOffsetMinutes = 0,
-        self.timeZone = "",
-        self.chipset = "",
-        self.glDeviceInfo = None,
+        self.clientInfo = None
+        self.poToken = None
+        self.playbackCookie = None
+        self.gp = None
+        self.field5 = []
+        self.field6 = []
+        self.field6 = ""
+        self.field6 = []
+
 
     @staticmethod
     def encode(message: dict, writer=None):
@@ -246,7 +396,7 @@ class StreamerContext:
         return writer
 
     @staticmethod
-    def decode_streamer_context_client_info(input_data, length=None):
+    def decode(input_data, length=None):
         reader = input_data if isinstance(input_data, BinaryReader) else BinaryReader(input_data)
         end = reader.len if length is None else reader.pos + length
         message = StreamerContext()
@@ -255,71 +405,34 @@ class StreamerContext:
             tag = reader.uint32()
             field_number = tag >> 3
 
-            if field_number == 12 and tag == 98:
-                message.deviceMake = reader.string()
+            if field_number == 1 and tag == 10:
+                message.clientInfo = StreamerContext_ClientInfo.decode(reader, reader.uint32())
                 continue
-            if field_number == 13 and tag == 106:
-                message.deviceModel = reader.string()
+            if field_number == 2 and tag == 18:
+                message.poToken = reader.bytes()
                 continue
-            if field_number == 16 and tag == 128:
-                message.clientName = reader.int32()
+            if field_number == 3 and tag == 26:
+                message.playbackCookie = PlaybackCookie.decode(reader, reader.uint32())
                 continue
-            if field_number == 17 and tag == 138:
-                message.clientVersion = reader.string()
+            if field_number == 4 and tag == 34:
+                message.gp = reader.bytes()
                 continue
-            if field_number == 18 and tag == 146:
-                message.osName = reader.string()
+            if field_number == 5 and tag == 42:
+                message.field5.append(StreamerContext_Fqa.decode(reader, reader.uint32()))
                 continue
-            if field_number == 19 and tag == 154:
-                message.osVersion = reader.string()
+            if field_number == 6 and tag == 48:
+                message.field6.append(reader.int32())
                 continue
-            if field_number == 21 and tag == 170:
-                message.acceptLanguage = reader.string()
+            if field_number == 6 and tag == 50:
+                end2 = reader.uint32() + reader.pos
+                while (reader.pos < end2):
+                    message.field6.append(reader.int32())
                 continue
-            if field_number == 22 and tag == 178:
-                message.acceptRegion = reader.string()
+            if field_number == 7 and tag == 58:
+                message.field7 = reader.string()
                 continue
-            if field_number == 37 and tag == 296:
-                message.screenWidthPoints = reader.int32()
-                continue
-            if field_number == 38 and tag == 304:
-                message.screenHeightPoints = reader.int32()
-                continue
-            if field_number == 39 and tag == 317:
-                message.screenWidthInches = reader.float()
-                continue
-            if field_number == 40 and tag == 325:
-                message.screenHeightInches = reader.float()
-                continue
-            if field_number == 41 and tag == 328:
-                message.screenPixelDensity = reader.int32()
-                continue
-            if field_number == 46 and tag == 368:
-                message.clientFormFactor = reader.int32()
-                continue
-            if field_number == 50 and tag == 400:
-                message.gmscoreVersionCode = reader.int32()
-                continue
-            if field_number == 55 and tag == 440:
-                message.windowWidthPoints = reader.int32()
-                continue
-            if field_number == 56 and tag == 448:
-                message.windowHeightPoints = reader.int32()
-                continue
-            if field_number == 64 and tag == 512:
-                message.androidSdkVersion = reader.int32()
-                continue
-            if field_number == 65 and tag == 525:
-                message.screenDensityFloat = reader.float()
-                continue
-            if field_number == 67 and tag == 536:
-                message.utcOffsetMinutes = long_to_number(reader.int64())
-                continue
-            if field_number == 80 and tag == 642:
-                message.timeZone = reader.string()
-                continue
-            if field_number == 92 and tag == 738:
-                message.chipset = reader.string()
+            if field_number == 8 and tag == 66:
+                message.field5.append(StreamerContext_Gqa.decode(reader, reader.uint32()))
                 continue
 
             if (tag & 7) == 4 or tag == 0:

--- a/pytubefix/sabr/video_streaming/time_range.py
+++ b/pytubefix/sabr/video_streaming/time_range.py
@@ -1,0 +1,51 @@
+# All credits to https://github.com/LuanRT/googlevideo
+
+from typing import Optional
+
+from pytubefix.sabr.proto import BinaryReader, BinaryWriter
+
+
+class TimeRange:
+    def __init__(self):
+        self.start: int = 0
+        self.duration: int = 0
+        self.timescale: int = 0
+
+    @staticmethod
+    def decode(reader: BinaryReader, length: Optional[int] = None) -> 'TimeRange':
+        end = reader.len if length is None else reader.pos + length
+        message = TimeRange()
+        while reader.pos < end:
+            tag = reader.uint32()
+            field = tag >> 3
+
+            if field == 1 and tag == 8:
+                message.start = long_to_number(reader.int64())
+            elif field == 2 and tag == 16:
+                message.duration = long_to_number(reader.int64())
+            elif field == 3 and tag == 24:
+                message.timescale = reader.int32()
+            elif (tag & 7) == 4 or tag == 0:
+                break
+            else:
+                reader.skip(tag & 7)
+        return message
+
+    def encode(self, writer: Optional[BinaryWriter] = None) -> BinaryWriter:
+        writer = writer or BinaryWriter()
+
+        if self.start != 0:
+            writer.uint32(8).int64(self.start)
+        if self.duration != 0:
+            writer.uint32(16).int64(self.duration)
+        if self.timescale != 0:
+            writer.uint32(24).int32(self.timescale)
+        return writer
+
+def long_to_number(int64_value):
+    value = int(str(int64_value))
+    if value > (2 ** 53 - 1):
+        raise OverflowError("Value is larger than 9007199254740991")
+    if value < -(2 ** 53 - 1):
+        raise OverflowError("Value is smaller than -9007199254740991")
+    return value

--- a/pytubefix/sabr/video_streaming/time_range.py
+++ b/pytubefix/sabr/video_streaming/time_range.py
@@ -12,23 +12,29 @@ class TimeRange:
         self.timescale: int = 0
 
     @staticmethod
-    def decode(reader: BinaryReader, length: Optional[int] = None) -> 'TimeRange':
+    def decode(input_data, length=None):
+        reader = input_data if isinstance(input_data, BinaryReader) else BinaryReader(input_data)
         end = reader.len if length is None else reader.pos + length
-        message = TimeRange()
+        message = TimeRange
+
         while reader.pos < end:
             tag = reader.uint32()
             field = tag >> 3
 
             if field == 1 and tag == 8:
                 message.start = long_to_number(reader.int64())
+                continue
             elif field == 2 and tag == 16:
                 message.duration = long_to_number(reader.int64())
+                continue
             elif field == 3 and tag == 24:
                 message.timescale = reader.int32()
+                continue
             elif (tag & 7) == 4 or tag == 0:
                 break
             else:
                 reader.skip(tag & 7)
+
         return message
 
     def encode(self, writer: Optional[BinaryWriter] = None) -> BinaryWriter:

--- a/pytubefix/sabr/video_streaming/video_playback_abr_request.py
+++ b/pytubefix/sabr/video_streaming/video_playback_abr_request.py
@@ -1,0 +1,406 @@
+# All credits to https://github.com/LuanRT/googlevideo
+
+import struct
+from typing import List, Optional
+
+from pytubefix.sabr.common import FormatId
+from pytubefix.sabr.proto import BinaryWriter
+from pytubefix.sabr.video_streaming.buffered_range import BufferedRange
+from pytubefix.sabr.video_streaming.client_abr_state import ClientAbrState
+from pytubefix.sabr.video_streaming.streamer_context import StreamerContext
+
+
+class VideoPlaybackAbrRequest:
+    def __init__(self):
+        self.client_abr_state: Optional[ClientAbrState] = None
+        self.selected_format_ids: List[FormatId] = []
+        self.buffered_ranges: List[BufferedRange] = []
+        self.player_time_ms: int = 0
+        self.video_playback_ustreamer_config: bytes = bytes()
+        self.lo: Optional[Lo] = None
+        self.selected_audio_format_ids: List[FormatId] = []
+        self.selected_video_format_ids: List[FormatId] = []
+        self.streamer_context: Optional[StreamerContext] = None
+        self.field21: Optional[OQa] = None
+        self.field22: int = 0
+        self.field23: int = 0
+        self.field1000: List[Pqa] = []
+
+    def finish(self) -> bytes:
+        # Flush the buffer
+        if self.buf:
+            self.chunks.append(bytes(self.buf))
+            self.buf = bytearray()
+
+        # Calculate total length
+        total_length = sum(len(chunk) for chunk in self.chunks)
+
+        # Concatenate all chunks
+        result = bytearray(total_length)
+        offset = 0
+        for chunk in self.chunks:
+            result[offset:offset + len(chunk)] = chunk
+            offset += len(chunk)
+
+        # Clear chunks
+        self.chunks = []
+
+        return bytes(result)
+
+    @staticmethod
+    def encode(message: dict, writer=None):
+        if writer is None:
+            writer = BinaryWriter()
+
+        if "clientAbrState" in message and message["clientAbrState"] is not None:
+            writer.uint32(10)
+            ClientAbrState.encode(message["clientAbrState"], writer.fork())
+            writer.join()
+
+        for v in message.get("selectedFormatIds", []):
+            writer.uint32(18)
+            FormatId.encode(v, writer.fork())
+            writer.join()
+
+        for v in message.get("bufferedRanges", []):
+            writer.uint32(26)
+            BufferedRange.encode(v, writer.fork())
+            writer.join()
+
+        if message.get("playerTimeMs", 0):
+            writer.uint32(32).int64(message["playerTimeMs"])
+
+        if message.get("videoPlaybackUstreamerConfig", b''):
+            writer.uint32(42).bytes(message["videoPlaybackUstreamerConfig"])
+
+        if "lo" in message and message["lo"] is not None:
+            writer.uint32(50)
+            Lo.encode(message["lo"], writer.fork())
+            writer.join()
+
+        for v in message.get("selectedAudioFormatIds", []):
+            writer.uint32(130)
+            FormatId.encode(v, writer.fork())
+            writer.join()
+
+        for v in message.get("selectedVideoFormatIds", []):
+            writer.uint32(138)
+            FormatId.encode(v, writer.fork())
+            writer.join()
+
+        if "streamerContext" in message and message["streamerContext"] is not None:
+            writer.uint32(154)
+            StreamerContext.encode(message["streamerContext"], writer.fork())
+            writer.join()
+
+        if "field21" in message and message["field21"] is not None:
+            writer.uint32(170)
+            OQa.encode(message["field21"], writer.fork())
+            writer.join()
+
+        if message.get("field22", 0):
+            writer.uint32(176).int32(message["field22"])
+
+        if message.get("field23", 0):
+            writer.uint32(184).int32(message["field23"])
+
+        for v in message.get("field1000", []):
+            writer.uint32(8002)
+            Pqa.encode(v, writer.fork())
+            writer.join()
+
+        return writer
+
+    @staticmethod
+    def decode(data):
+        message = VideoPlaybackAbrRequest()
+        pos = 0
+
+        while pos < len(data):
+            field_number, wire_type = struct.unpack('>BB', data[pos:pos + 2])
+            pos += 2
+
+            if wire_type == 2:  # Length-delimited
+                length = struct.unpack('>I', data[pos:pos + 4])[0]
+                pos += 4
+                field_data = data[pos:pos + length]
+                pos += length
+
+                if field_number == 1:
+                    message.client_abr_state = ClientAbrState.decode(field_data)
+                elif field_number == 2:
+                    message.selected_format_ids.append(FormatId.decode(field_data))
+                elif field_number == 3:
+                    message.buffered_ranges.append(BufferedRange.decode(field_data))
+                elif field_number == 5:
+                    message.video_playback_ustreamer_config = field_data
+                elif field_number == 6:
+                    message.lo = Lo.decode(field_data)
+                elif field_number == 16:
+                    message.selected_audio_format_ids.append(FormatId.decode(field_data))
+                elif field_number == 17:
+                    message.selected_video_format_ids.append(FormatId.decode(field_data))
+                elif field_number == 19:
+                    message.streamer_context = StreamerContext.decode(field_data)
+                elif field_number == 21:
+                    message.field21 = OQa.decode(field_data)
+                elif field_number == 1000:
+                    message.field1000.append(Pqa.decode(field_data))
+
+            elif wire_type == 0:  # Varint
+                if field_number == 4:
+                    message.player_time_ms = struct.unpack('>Q', data[pos:pos + 8])[0]
+                    pos += 8
+                elif field_number == 22:
+                    message.field22 = struct.unpack('>i', data[pos:pos + 4])[0]
+                    pos += 4
+                elif field_number == 23:
+                    message.field23 = struct.unpack('>i', data[pos:pos + 4])[0]
+                    pos += 4
+
+        return message
+
+
+class Lo:
+    def __init__(self):
+        self.format_id: Optional[FormatId] = None
+        self.lj: int = 0
+        self.sequence_number: int = 0
+        self.field4: Optional[Lo_Field4] = None
+        self.mz: int = 0
+
+    @staticmethod
+    def encode(message):
+        data = bytearray()
+
+        if message.format_id is not None:
+            data.extend(struct.pack('>B', 10))
+            format_id_data = FormatId.encode(message.format_id)
+            data.extend(struct.pack('>I', len(format_id_data)))
+            data.extend(format_id_data)
+
+        if message.lj != 0:
+            data.extend(struct.pack('>Bi', 16, message.lj))
+
+        if message.sequence_number != 0:
+            data.extend(struct.pack('>Bi', 24, message.sequence_number))
+
+        if message.field4 is not None:
+            data.extend(struct.pack('>B', 34))
+            field4_data = Lo_Field4.encode(message.field4)
+            data.extend(struct.pack('>I', len(field4_data)))
+            data.extend(field4_data)
+
+        if message.mz != 0:
+            data.extend(struct.pack('>Bi', 40, message.mz))
+
+        return bytes(data)
+
+    @staticmethod
+    def decode(data):
+        message = Lo()
+        pos = 0
+
+        while pos < len(data):
+            field_number, wire_type = struct.unpack('>BB', data[pos:pos + 2])
+            pos += 2
+
+            if wire_type == 2:  # Length-delimited
+                length = struct.unpack('>I', data[pos:pos + 4])[0]
+                pos += 4
+                field_data = data[pos:pos + length]
+                pos += length
+
+                if field_number == 1:
+                    message.format_id = FormatId.decode(field_data)
+                elif field_number == 4:
+                    message.field4 = Lo_Field4.decode(field_data)
+
+            elif wire_type == 0:  # Varint
+                if field_number == 2:
+                    message.lj = struct.unpack('>i', data[pos:pos + 4])[0]
+                    pos += 4
+                elif field_number == 3:
+                    message.sequence_number = struct.unpack('>i', data[pos:pos + 4])[0]
+                    pos += 4
+                elif field_number == 5:
+                    message.mz = struct.unpack('>i', data[pos:pos + 4])[0]
+                    pos += 4
+
+        return message
+
+
+class Lo_Field4:
+    def __init__(self):
+        self.field1: int = 0
+        self.field2: int = 0
+        self.field3: int = 0
+
+    @staticmethod
+    def encode(message):
+        data = bytearray()
+
+        if message.field1 != 0:
+            data.extend(struct.pack('>Bi', 8, message.field1))
+
+        if message.field2 != 0:
+            data.extend(struct.pack('>Bi', 16, message.field2))
+
+        if message.field3 != 0:
+            data.extend(struct.pack('>Bi', 24, message.field3))
+
+        return bytes(data)
+
+    @staticmethod
+    def decode(data):
+        message = Lo_Field4()
+        pos = 0
+
+        while pos < len(data):
+            field_number = struct.unpack('>B', data[pos:pos + 1])[0]
+            pos += 1
+            wire_type = field_number & 0x7
+            field_number >>= 3
+
+            if wire_type == 0:  # Varint
+                if field_number == 1:
+                    message.field1 = struct.unpack('>i', data[pos:pos + 4])[0]
+                    pos += 4
+                elif field_number == 2:
+                    message.field2 = struct.unpack('>i', data[pos:pos + 4])[0]
+                    pos += 4
+                elif field_number == 3:
+                    message.field3 = struct.unpack('>i', data[pos:pos + 4])[0]
+                    pos += 4
+
+        return message
+
+
+class OQa:
+    def __init__(self):
+        self.field1: List[str] = []
+        self.field2: bytes = bytes()
+        self.field3: str = ""
+        self.field4: int = 0
+        self.field5: int = 0
+        self.field6: str = ""
+
+    @staticmethod
+    def encode(message):
+        data = bytearray()
+
+        for value in message.field1:
+            data.extend(struct.pack('>B', 10))
+            data.extend(struct.pack('>I', len(value)))
+            data.extend(value.encode('utf-8'))
+
+        if len(message.field2) > 0:
+            data.extend(struct.pack('>B', 18))
+            data.extend(struct.pack('>I', len(message.field2)))
+            data.extend(message.field2)
+
+        if message.field3 != "":
+            data.extend(struct.pack('>B', 26))
+            data.extend(struct.pack('>I', len(message.field3)))
+            data.extend(message.field3.encode('utf-8'))
+
+        if message.field4 != 0:
+            data.extend(struct.pack('>Bi', 32, message.field4))
+
+        if message.field5 != 0:
+            data.extend(struct.pack('>Bi', 40, message.field5))
+
+        if message.field6 != "":
+            data.extend(struct.pack('>B', 50))
+            data.extend(struct.pack('>I', len(message.field6)))
+            data.extend(message.field6.encode('utf-8'))
+
+        return bytes(data)
+
+    @staticmethod
+    def decode(data):
+        message = OQa()
+        pos = 0
+
+        while pos < len(data):
+            field_number, wire_type = struct.unpack('>BB', data[pos:pos + 2])
+            pos += 2
+
+            if wire_type == 2:  # Length-delimited
+                length = struct.unpack('>I', data[pos:pos + 4])[0]
+                pos += 4
+                field_data = data[pos:pos + length]
+                pos += length
+
+                if field_number == 1:
+                    message.field1.append(field_data.decode('utf-8'))
+                elif field_number == 2:
+                    message.field2 = field_data
+                elif field_number == 3:
+                    message.field3 = field_data.decode('utf-8')
+                elif field_number == 6:
+                    message.field6 = field_data.decode('utf-8')
+
+            elif wire_type == 0:  # Varint
+                if field_number == 4:
+                    message.field4 = struct.unpack('>i', data[pos:pos + 4])[0]
+                    pos += 4
+                elif field_number == 5:
+                    message.field5 = struct.unpack('>i', data[pos:pos + 4])[0]
+                    pos += 4
+
+        return message
+
+
+class Pqa:
+    def __init__(self):
+        self.formats: List[FormatId] = []
+        self.ud: List[BufferedRange] = []
+        self.clip_id: str = ""
+
+    @staticmethod
+    def encode(message):
+        data = bytearray()
+
+        for format_id in message.formats:
+            data.extend(struct.pack('>B', 10))
+            format_id_data = FormatId.encode(format_id)
+            data.extend(struct.pack('>I', len(format_id_data)))
+            data.extend(format_id_data)
+
+        for buffered_range in message.ud:
+            data.extend(struct.pack('>B', 18))
+            buffered_range_data = BufferedRange.encode(buffered_range)
+            data.extend(struct.pack('>I', len(buffered_range_data)))
+            data.extend(buffered_range_data)
+
+        if message.clip_id != "":
+            data.extend(struct.pack('>B', 26))
+            data.extend(struct.pack('>I', len(message.clip_id)))
+            data.extend(message.clip_id.encode('utf-8'))
+
+        return bytes(data)
+
+    @staticmethod
+    def decode(data):
+        message = Pqa()
+        pos = 0
+
+        while pos < len(data):
+            field_number, wire_type = struct.unpack('>BB', data[pos:pos + 2])
+            pos += 2
+
+            if wire_type == 2:  # Length-delimited
+                length = struct.unpack('>I', data[pos:pos + 4])[0]
+                pos += 4
+                field_data = data[pos:pos + length]
+                pos += length
+
+                if field_number == 1:
+                    message.formats.append(FormatId.decode(field_data))
+                elif field_number == 2:
+                    message.ud.append(BufferedRange.decode(field_data))
+                elif field_number == 3:
+                    message.clip_id = field_data.decode('utf-8')
+
+        return message

--- a/pytubefix/sabr/video_streaming/video_playback_abr_request.py
+++ b/pytubefix/sabr/video_streaming/video_playback_abr_request.py
@@ -26,27 +26,6 @@ class VideoPlaybackAbrRequest:
         self.field23: int = 0
         self.field1000: List[Pqa] = []
 
-    def finish(self) -> bytes:
-        # Flush the buffer
-        if self.buf:
-            self.chunks.append(bytes(self.buf))
-            self.buf = bytearray()
-
-        # Calculate total length
-        total_length = sum(len(chunk) for chunk in self.chunks)
-
-        # Concatenate all chunks
-        result = bytearray(total_length)
-        offset = 0
-        for chunk in self.chunks:
-            result[offset:offset + len(chunk)] = chunk
-            offset += len(chunk)
-
-        # Clear chunks
-        self.chunks = []
-
-        return bytes(result)
-
     @staticmethod
     def encode(message: dict, writer=None):
         if writer is None:

--- a/pytubefix/streams.py
+++ b/pytubefix/streams.py
@@ -97,6 +97,7 @@ class Stream:
         self.is_3d = itag_profile["is_3d"]
         self.is_hdr = itag_profile["is_hdr"]
         self.is_live = itag_profile["is_live"]
+        self.is_drc = stream.get('isDrc', False)
         self._is_sabr = stream.get('is_sabr', False)
         self.durationMs = stream['approxDurationMs']
         self.last_Modified = stream['lastModified']
@@ -117,8 +118,6 @@ class Stream:
             self.audio_track_language_id_regionalized = None
             self.audio_track_language_id= None
 
-        self._unprocessed_audio: bool = self.xtags and 'audioTrack' not in stream
-
     @property
     def is_adaptive(self) -> bool:
         """Whether the stream is DASH.
@@ -136,13 +135,6 @@ class Stream:
         :rtype: bool
         """
         return not self.is_adaptive
-
-    @property
-    def unprocessed_audio(self) -> bool:
-        """
-        YouTube may upload dubbed audio streams that are not available
-        """
-        return self._unprocessed_audio
 
     @property
     def is_sabr(self) -> bool:

--- a/pytubefix/streams.py
+++ b/pytubefix/streams.py
@@ -407,7 +407,7 @@ class Stream:
                         write_chunk(chunk, bytes_remaining)
                 else:
                     logger.debug('This stream is SABR. Starting ServerAbrStream')
-                    ServerAbrStream(stream=self, write_chunk=write_chunk).start()
+                    ServerAbrStream(stream=self, write_chunk=write_chunk, monostate=self._monostate).start()
 
             except HTTPError as e:
                 if e.code != 404:
@@ -428,7 +428,7 @@ class Stream:
                         write_chunk(chunk, bytes_remaining)
                 else:
                     logger.debug('This stream is SABR. Starting ServerAbrStream')
-                    ServerAbrStream(stream=self, write_chunk=write_chunk).start()
+                    ServerAbrStream(stream=self, write_chunk=write_chunk, monostate=self._monostate).start()
 
             self.on_complete(file_path)
             return file_path

--- a/pytubefix/streams.py
+++ b/pytubefix/streams.py
@@ -117,6 +117,8 @@ class Stream:
             self.audio_track_language_id_regionalized = None
             self.audio_track_language_id= None
 
+        self._unprocessed_audio: bool = self.xtags and 'audioTrack' not in stream
+
     @property
     def is_adaptive(self) -> bool:
         """Whether the stream is DASH.
@@ -134,6 +136,13 @@ class Stream:
         :rtype: bool
         """
         return not self.is_adaptive
+
+    @property
+    def unprocessed_audio(self) -> bool:
+        """
+        YouTube may upload dubbed audio streams that are not available
+        """
+        return self._unprocessed_audio
 
     @property
     def is_sabr(self) -> bool:

--- a/pytubefix/version.py
+++ b/pytubefix/version.py
@@ -1,4 +1,4 @@
-__version__ = "9.0.0"
+__version__ = "9.0.1"
 
 if __name__ == "__main__":
     print(__version__)


### PR DESCRIPTION
### All this work is a translation into python of the excellent work [https://github.com/LuanRT/googlevideo](https://github.com/LuanRT/googlevideo). 

Initially, YouTube used a streaming technique called Dynamic Adaptive Streaming over HTTP (DASH), which basically involves the client requesting the best video and audio stream based on network statistics and client preferences. These streams have the audio and video in separate files that are interpreted by the player.

Around 2 years ago YouTube started implementing Server ABR (SABR) It allows the server to dynamically adjust streaming based on the user's network conditions. See more technical details here [https://github.com/LuanRT/yt-sabr-shaka-demo](https://github.com/LuanRT/yt-sabr-shaka-demo).

In short, SABR has the server URL to which a payload with some encoded configurations must be sent. The server will send a response that contains several media and configuration parts that must be processed correctly to obtain a stream.

### Known issues

* The server may return invalid chunks for various reasons, in most cases pytubefix will automatically retry (limit of 3 attempts before throwing an exception).

* The server may send a non-media part, internally named `SABR_CONTEXT_UPDATE`. This part is not yet documented and its operation is still unknown. It is most commonly seen in newly published videos and requires a new attempt manually.

### Changes

* Added support for SABR streams #468 

Special thanks to @NannoSilver for helping me with the testing.