### PR TITLE
Update the get_default_audio_track() to match "original" audio track and add "SABR" to message

### DIFF
--- a/pytubefix/sabr/core/server_abr_stream.py
+++ b/pytubefix/sabr/core/server_abr_stream.py
@@ -148,7 +148,7 @@ class ServerAbrStream:
                 self.RELOAD = False
                 continue
             elif self.maximum_reload_attempt <= 0:
-                raise SABRError("Maximum reload attempts reached")
+                raise SABRError("SABR Maximum reload attempts reached")
 
             if (
                     not main_format or

--- a/pytubefix/streams.py
+++ b/pytubefix/streams.py
@@ -106,7 +106,7 @@ class Stream:
 
         self.includes_multiple_audio_tracks: bool = 'audioTrack' in stream
         if self.includes_multiple_audio_tracks:
-            self.is_default_audio_track = stream['audioTrack']['audioIsDefault']
+            self.is_default_audio_track = "original" in stream['audioTrack']['displayName']
             self.audio_track_name_regionalized = str(stream['audioTrack']['displayName']).replace(" original", "")
             self.audio_track_name = self.audio_track_name_regionalized.split(" ")[0]
             self.audio_track_language_id_regionalized= str(stream['audioTrack']['id']).split(".")[0]


### PR DESCRIPTION
The `get_default_audio_track()` function was originally designed to return the `default` audio track, which—until recently—was typically the same as the `original` track. However, due to changes on YouTube, the default track may now be a dubbed version in many cases.

This update modifies `get_default_audio_track()` to explicitly return the audio track that includes `original` in its name.

This is a copy of the development by @felipeucelli at https://github.com/felipeucelli/pytubefix/commit/7c8a03f532ba4cdc0ed8bbc3828919a57e43e47b



--------

The `Maximum reload attempts reached` error message might appear too generic, particularly when the associated SABRError is not clearly identified, or not preserved, during the error analysis and handling.

This small update adds `SABR` to the message, making it explicitly clear that the message originates from the SABR.