### PR TITLE
Extend support for detecting members-only videos

### DIFF
--- a/pytubefix/__main__.py
+++ b/pytubefix/__main__.py
@@ -377,6 +377,9 @@ class YouTube:
                 ):
                     raise exceptions.MembersOnly(video_id=self.video_id)
 
+                elif 'Join this channel to get access to members-only content and other exclusive perks.' in reason:
+                    raise exceptions.MembersOnly(video_id=self.video_id)
+
                 elif reason == 'This live stream recording is not available.':
                     raise exceptions.RecordingUnavailable(video_id=self.video_id)
 


### PR DESCRIPTION
This adds a new handler to detect `members-only` videos and raises the appropriate `pytubefix.exceptions.MembersOnly` exception.

This is based on the error message returned by the video at https://www.youtube.com/watch?v=uHbIdhOM1bA. When `status == 'UNPLAYABLE'`, the `reason` in `messages` is set to `This video is available to this channel's members on level: Just the Video Extras (or any higher level). Join this channel to get access to members-only content and other exclusive perks.`