### PR TITLE
Fixed oauth not able to retrieve metadata

### DIFF
--- a/pytubefix/__main__.py
+++ b/pytubefix/__main__.py
@@ -798,6 +798,9 @@ class YouTube:
         """Sets the publish date."""
         self._publish_date = value
 
+    def vid_engagement_items(self) -> list:
+        return self.vid_details['engagementPanels'][1]['engagementPanelSectionListRenderer']['content']['structuredDescriptionContentRenderer']['items']
+
     @property
     def title(self) -> str:
         """Get the video title.
@@ -810,6 +813,9 @@ class YouTube:
 
         if self._title:
             return self._title
+
+        if self.use_oauth == True:
+            self._title = self.vid_engagement_items()[0]['videoDescriptionHeaderRenderer']['title']['runs'][0]['text']
 
         try:
             # Some clients may not return the title in the `player` endpoint,
@@ -897,6 +903,10 @@ class YouTube:
         :rtype: str
         """
         description = self.vid_info.get("videoDetails", {}).get("shortDescription")
+
+        if self.use_oauth == True:
+            description = self.vid_engagement_items()[2]['expandableVideoDescriptionBodyRenderer']['descriptionBodyText']['runs'][0]['text']
+
         if description is None:
             # TV client structure
             results = self.vid_details['contents']['twoColumnWatchNextResults']['results']['results']['contents']
@@ -931,6 +941,11 @@ class YouTube:
         :rtype: int
         """
         view = int(self.vid_info.get("videoDetails", {}).get("viewCount", "0"))
+
+        if self.use_oauth == True:
+            simple_text = self.vid_engagement_items()[0]['videoDescriptionHeaderRenderer']['views']['simpleText']
+            view = int(''.join([char for char in simple_text if char.isdigit()]))
+
         if not view:
             results = self.vid_details['contents']['twoColumnWatchNextResults']['results']['results']['contents']
             for c in results:
@@ -952,6 +967,10 @@ class YouTube:
 
         # TODO: Implement correctly for the TV client
         _author = self.vid_info.get("videoDetails", {}).get("author", "unknown")
+
+        if self.use_oauth == True:
+            _author = self.vid_engagement_items()[0]['videoDescriptionHeaderRenderer']['channel']['simpleText']
+
 
         self._author = _author
         return self._author
@@ -991,6 +1010,10 @@ class YouTube:
 
         :rtype: str
         """
+        
+        if self.use_oauth == True:
+            return self.vid_engagement_items()[0]['videoDescriptionHeaderRenderer']['factoid'][0]['factoidRenderer']['value']['simpleText']
+
         try:
             likes = '0'
             contents = self.vid_details[


### PR DESCRIPTION
Fixes a whole bunch of the oauth requests like (https://github.com/JuanBindez/pytubefix/issues/560, https://github.com/JuanBindez/pytubefix/issues/539 and https://github.com/JuanBindez/pytubefix/issues/498) which I was looking into

I used a brute force search to find paths that have title, author, description, likes and views under the 'engagementPanels' in YouTube.vid_details put the path in a function called vid_engagement_items which returns the list where all the above metadata resides

Then in all the metadata functions, I check if user is using o_auth, if true then use engagementPanels to retrieve metadata