### PR TITLE
iterate over dynamic range in vid_engagement_items

### DIFF
--- a/pytubefix/__main__.py
+++ b/pytubefix/__main__.py
@@ -799,7 +799,7 @@ class YouTube:
         self._publish_date = value
 
     def vid_engagement_items(self) -> list:
-        for i in range(1,4):
+        for i in range(len(self.vid_details.get('engagementPanels', []))):
             try:
                 return self.vid_details['engagementPanels'][i]['engagementPanelSectionListRenderer']['content']['structuredDescriptionContentRenderer']['items']
             except KeyError as e:


### PR DESCRIPTION

Videos without comments gives list index out of range error when accessing details #565 #564, since they have 3 instead of 4 vid_engagement_items.
Now iterates over list length instead of fixed number.