### PR TITLE
likes: return empty string when video details payload has no contents

### DIFF
--- a/pytubefix/__main__.py
+++ b/pytubefix/__main__.py
@@ -911,11 +911,21 @@ class YouTube:
         try:
             contents = self.vid_details['contents']
             results = contents[list(contents.keys())[0]]['results']['results']['contents']
+        except KeyError as e:
+            # `vid_details` is `None`-or-missing-key when the Channel iterator
+            # returns a video whose details payload doesn't include `contents`.
+            # Surface the empty case as PyTubeFixError so callers can decide
+            # how to handle it (likes/dislikes/views catch and return 0 or
+            # raise; see #595 — looping over a Channel previously crashed
+            # mid-iteration on the first video without a details block).
+            raise exceptions.PyTubeFixError(
+                f'Exception: accessing vid_details_content of {self.watch_url} in {self.client}: missing key {e!s}'
+            ) from e
         except Exception as e:
             raise exceptions.PyTubeFixError(
-                    (
-                        f'Exception: accessing vid_details_content of {self.watch_url} in {self.client} and trying to use key in {contents.keys()}'
-                    )
+                (
+                    f'Exception: accessing vid_details_content of {self.watch_url} in {self.client} and trying to use key in {contents.keys()}'
+                )
             ) from e
         return results
 
@@ -1072,6 +1082,12 @@ class YouTube:
                         f'Exception: accessing likes of {self.watch_url} in {self.client}'
                     )
             ) from e
+        except exceptions.PyTubeFixError:
+            # vid_details_content raises when the details payload is missing;
+            # skip videos where YouTube didn't return like counts (#595) and
+            # leave callers a deterministic empty value instead of crashing
+            # mid-iteration over a Channel.
+            return ''
         return None
 
     @property


### PR DESCRIPTION
Fixes #595.

Iterating a Channel's videos and calling `.likes` on each previously crashed mid-loop with `KeyError: 'contents'` from `vid_details_content` whenever YouTube's response for a particular video did not include the details `contents` block (the user hit it after 30–50 videos). The existing `try/except (KeyError, IndexError)` in `likes` didn't catch the `PyTubeFixError` that `vid_details_content` raised, so the exception escaped the property entirely.

Catch `PyTubeFixError` in `likes` and return an empty string for that video, matching the existing `likes = '0'` empty-default semantics. `vid_details_content` itself stays raising — other callers can decide their own fallback.