### PR TITLE
channel: forward all kwargs to Playlist parent so proxies are honored

### DIFF
--- a/pytubefix/contrib/channel.py
+++ b/pytubefix/contrib/channel.py
@@ -52,7 +52,17 @@ class Channel(Playlist):
             The verifier will return the visitorData and po_token respectively.
             (if passed, else default verifier will be used)
         """
-        super().__init__(url, proxies)
+        super().__init__(
+            url,
+            client=client,
+            proxies=proxies,
+            use_oauth=use_oauth,
+            allow_oauth_cache=allow_oauth_cache,
+            token_file=token_file,
+            oauth_verifier=oauth_verifier,
+            use_po_token=use_po_token,
+            po_token_verifier=po_token_verifier,
+        )
 
         self.channel_uri = extract.channel_name(url)
 

--- a/tests/contrib/test_channel.py
+++ b/tests/contrib/test_channel.py
@@ -75,5 +75,20 @@ def test_videos_html(request_get, channel_videos_html):
     c = Channel('https://www.youtube.com/c/ProgrammingKnowledge')
     assert c.html == channel_videos_html
 
+
+@mock.patch('pytubefix.contrib.playlist.install_proxy')
+@mock.patch('pytubefix.request.get')
+def test_channel_proxies_are_installed(request_get, install_proxy_mock,
+                                       channel_videos_html):
+    request_get.return_value = channel_videos_html
+    proxies = {
+        'http': 'http://user:pass@proxy.example.com:8080',
+        'https': 'http://user:pass@proxy.example.com:8080',
+    }
+    Channel('https://www.youtube.com/c/ProgrammingKnowledge/videos',
+            proxies=proxies)
+    install_proxy_mock.assert_called_once_with(proxies)
+
+
 # Because the Channel object subclasses the Playlist object, most of the tests
 # are already taken care of by the Playlist test suite.


### PR DESCRIPTION
Fixes #596. `Channel.__init__` was calling `super().__init__(url, proxies)`, but `Playlist`'s second positional parameter is `client`, so the proxies dict landed in `client` and `install_proxy` was never invoked. Pass all kwargs through explicitly and add a regression test that asserts `install_proxy` is called when `proxies=` is supplied.