### PR TITLE
Add official project logo and improve README branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,9 @@
   />
 </p>
 
-<h1 align="center">Pytubefix</h1>
-
-<p align="center">
+<h2 align="center">
   Python3 Library for Downloading YouTube Videos
-</p>
+</h2>
 
 <p align="center">
   <a href="https://pypi.org/project/pytubefix/">

--- a/README.md
+++ b/README.md
@@ -1,13 +1,42 @@
-# Pytubefix
+<p align="center">
+  <img
+    width="220"
+    alt="pytubefix_logo"
+    src="https://github.com/user-attachments/assets/b28b3379-4b72-4846-b2c4-2ade07202e45"
+  />
+</p>
 
-[![PyPI - Downloads](https://img.shields.io/pypi/dm/pytubefix)](https://pypi.org/project/pytubefix/)
-[![GitHub Sponsors](https://img.shields.io/github/sponsors/juanbindez)](https://github.com/sponsors/juanbindez)
-[![PyPI - License](https://img.shields.io/pypi/l/pytubefix)](https://opensource.org/licenses/MIT)
-[![Read the Docs](https://img.shields.io/readthedocs/pytubefix)](https://pytubefix.readthedocs.io/)
-[![GitHub Tag](https://img.shields.io/github/v/tag/JuanBindez/pytubefix?include_prereleases)](https://github.com/JuanBindez/pytubefix/releases)
-[![PyPI - Version](https://img.shields.io/pypi/v/pytubefix)](https://pypi.org/project/pytubefix/)
+<h1 align="center">Pytubefix</h1>
 
-## Python3 Library for Downloading YouTube Videos
+<p align="center">
+  Python3 Library for Downloading YouTube Videos
+</p>
+
+<p align="center">
+  <a href="https://pypi.org/project/pytubefix/">
+    <img src="https://img.shields.io/pypi/dm/pytubefix" alt="PyPI Downloads">
+  </a>
+
+  <a href="https://github.com/sponsors/juanbindez">
+    <img src="https://img.shields.io/github/sponsors/juanbindez" alt="GitHub Sponsors">
+  </a>
+
+  <a href="https://opensource.org/licenses/MIT">
+    <img src="https://img.shields.io/pypi/l/pytubefix" alt="License">
+  </a>
+
+  <a href="https://pytubefix.readthedocs.io/">
+    <img src="https://img.shields.io/readthedocs/pytubefix" alt="Read the Docs">
+  </a>
+
+  <a href="https://github.com/JuanBindez/pytubefix/releases">
+    <img src="https://img.shields.io/github/v/tag/JuanBindez/pytubefix?include_prereleases" alt="GitHub Tag">
+  </a>
+
+  <a href="https://pypi.org/project/pytubefix/">
+    <img src="https://img.shields.io/pypi/v/pytubefix" alt="PyPI Version">
+  </a>
+</p>
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
   />
 </p>
 
-<h2 align="center">
+<h1 align="center">
   Python3 Library for Downloading YouTube Videos
-</h2>
+</h1>
 
 <p align="center">
   <a href="https://pypi.org/project/pytubefix/">
@@ -36,7 +36,6 @@
   </a>
 </p>
 
----
 
 ## Installation
 


### PR DESCRIPTION
## Changes

* Introduced the official Pytubefix project logo
* Added logo to the top of the README
* Center-aligned branding elements for better presentation
* Improved project identity and visual recognition on GitHub and PyPI

## Result

The project now has a consistent visual identity with a dedicated logo, giving the repository a more polished and professional appearance.
