### PR TITLE
Return strings from Channel.video_urls

### DIFF
--- a/pytubefix/contrib/channel.py
+++ b/pytubefix/contrib/channel.py
@@ -217,13 +217,32 @@ class Channel(Playlist):
 
         :Yields: Video URLs
         """
+        for obj in self._object_generator():
+            if isinstance(obj, str):
+                yield self._video_url(obj) if obj.startswith("/watch") else obj
+                continue
+
+            watch_url = getattr(obj, "watch_url", None)
+            if watch_url:
+                yield watch_url
+
+    def _object_generator(self):
+        """Generator that yields extracted channel objects."""
         for page in self._paginate(self.html):
             for obj in page:
-                yield obj
+                yield from self._iter_extracted_objects(obj)
+
+    @staticmethod
+    def _iter_extracted_objects(obj):
+        """Flatten extracted channel objects."""
+        if isinstance(obj, list):
+            for item in obj:
+                yield from Channel._iter_extracted_objects(item)
+        elif obj:
+            yield obj
 
     def videos_generator(self):
-        for url in self.video_urls:
-            yield url
+        yield from self._object_generator()
 
     def _get_active_tab(self, initial_data) -> dict:
         """ Receive the raw json and return the active page.


### PR DESCRIPTION
## Summary

This PR fixes #627, where `Channel.video_urls` was returning `YouTube` objects instead of URL strings.

The issue came from `Channel.url_generator()` yielding the extracted channel objects directly. Since `Channel.video_urls` is inherited from `Playlist`, it consumed that generator and exposed the objects instead of strings.

This patch separates the two paths:

- `Channel.video_urls` now returns string URLs again.
- `Channel.videos` continues to return the extracted `YouTube` objects.

## Verification

Ran:

pytubefix with patched channel.py on Python 3.13

Tested Manually and AI-assisted

"Channel.video_urls" now returns list in format:

[https://youtube.com/watch?video_id1, https://youtube.com/watch?videoid2, ...]

