### PR TITLE
Fix `completion_suggestions()` to handle missing `refinements` key

### DIFF
--- a/pytubefix/contrib/search.py
+++ b/pytubefix/contrib/search.py
@@ -390,7 +390,7 @@ class Search:
         if self._completion_suggestions:
             return self._completion_suggestions
         if self.results:
-            self._completion_suggestions = self._initial_results['refinements']
+            self._completion_suggestions = self._initial_results.get('refinements', [])
         return self._completion_suggestions
 
     def _get_results(self):


### PR DESCRIPTION
### Issue

The `completion_suggestions` method should return a list of strings but instead throws a KeyError as shown below:

```
line 393, in completion_suggestions
    self._completion_suggestions = self._initial_results['refinements']
                                   ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
KeyError: 'refinements'
```

The code tested:

```python
from pytubefix import Search

s = Search('Youtube RECAP 2021')

print(s.completion_suggestions)
```

### Solution 

This PR just adds a fallback to an empty list when calling `completion_suggestions`.