### PR TITLE
Spelling fix in docstrings of Channel and Playlist

### DIFF
--- a/pytubefix/contrib/channel.py
+++ b/pytubefix/contrib/channel.py
@@ -48,7 +48,7 @@ class Channel(Playlist):
             then passed as a `po_token` query parameter to affected clients.
             If allow_oauth_cache is set to True, the user should only be prompted once.
         :param Callable po_token_verifier:
-            (Optional) Verified used to obtain the visitorData and po_token.
+            (Optional) Verifier used to obtain the visitorData and po_token.
             The verifier will return the visitorData and po_token respectively.
             (if passed, else default verifier will be used)
         """

--- a/pytubefix/contrib/playlist.py
+++ b/pytubefix/contrib/playlist.py
@@ -49,7 +49,7 @@ class Playlist(Sequence):
             then passed as a `po_token` query parameter to affected clients.
             If allow_oauth_cache is set to True, the user should only be prompted once.
         :param Callable po_token_verifier:
-            (Optional) Verified used to obtain the visitorData and po_token.
+            (Optional) Verifier used to obtain the visitorData and po_token.
             The verifier will return the visitorData and po_token respectively.
             (if passed, else default verifier will be used)
         """


### PR DESCRIPTION
Spelling fix:  `Verified` -> `Verifier`