### PR TITLE
Fixes Issue #625

### DIFF
--- a/pytubefix/contrib/channel.py
+++ b/pytubefix/contrib/channel.py
@@ -48,7 +48,7 @@ class Channel(Playlist):
             then passed as a `po_token` query parameter to affected clients.
             If allow_oauth_cache is set to True, the user should only be prompted once.
         :param Callable po_token_verifier:
-            (Optional) Verified used to obtain the visitorData and po_token.
+            (Optional) Verifier used to obtain the visitorData and po_token.
             The verifier will return the visitorData and po_token respectively.
             (if passed, else default verifier will be used)
         """
@@ -380,7 +380,7 @@ class Channel(Playlist):
         """
         try:
             return YouTube(f"/watch?v="
-                           f"{x['richItemRenderer']['content']['videoRenderer']['videoId']}",
+                           f"{x['richItemRenderer']['content']['lockupViewModel']['contentId']}",
                            client=self.client,
                            use_oauth=self.use_oauth,
                            allow_oauth_cache=self.allow_oauth_cache,

--- a/pytubefix/contrib/playlist.py
+++ b/pytubefix/contrib/playlist.py
@@ -49,7 +49,7 @@ class Playlist(Sequence):
             then passed as a `po_token` query parameter to affected clients.
             If allow_oauth_cache is set to True, the user should only be prompted once.
         :param Callable po_token_verifier:
-            (Optional) Verified used to obtain the visitorData and po_token.
+            (Optional) Verifier used to obtain the visitorData and po_token.
             The verifier will return the visitorData and po_token respectively.
             (if passed, else default verifier will be used)
         """


### PR DESCRIPTION
Fix for #625. 

I tried to replicate the issue, but the channels I tried just came back as a nested empty list, `[[]]`.  With the fix it looks like I am getting everything and the newest video is the first in the list (which was part of the original issue).

The problem appears to be that the structure of the JSON has changed.  

`Channel._extract_video_id()` was throwing a `KeyError` on `['videoRenderer']`.  Then the except block's code was assuming that meant it was a short, but that was not the case. 

I am no expert on the structure of that hunk of JSON, so `['lockupViewModel']['contentId']` was chosen arbitrarily because it worked on the channels I tested...



I also fixed a typo in the `Channel` and `Playlist` docstrings.