### PR TITLE
extract: guard apply_signature with try/finally to release Cipher runners

### DIFF
--- a/pytubefix/extract.py
+++ b/pytubefix/extract.py
@@ -458,67 +458,75 @@ def apply_signature(stream_manifest: Dict, vid_info: Dict, js: str, url_js: str)
 
     """
     cipher = Cipher(js=js, js_url=url_js)
-    discovered_n = dict()
-    for i, stream in enumerate(stream_manifest):
-        try:
-            url: str = stream["url"]
-        except KeyError:
-            live_stream = (
-                vid_info.get("playabilityStatus", {}, )
-                .get("liveStreamability")
-            )
-            if live_stream:
-                raise LiveStreamError("UNKNOWN")
+    try:
+        discovered_n = dict()
+        for i, stream in enumerate(stream_manifest):
+            try:
+                url: str = stream["url"]
+            except KeyError:
+                live_stream = (
+                    vid_info.get("playabilityStatus", {}, )
+                    .get("liveStreamability")
+                )
+                if live_stream:
+                    raise LiveStreamError("UNKNOWN")
 
-        parsed_url = urlparse(url)
+            parsed_url = urlparse(url)
 
-        # Convert query params off url to dict
-        query_params = parse_qs(urlparse(url).query)
-        query_params = {
-            k: v[0] for k, v in query_params.items()
-        }
+            # Convert query params off url to dict
+            query_params = parse_qs(urlparse(url).query)
+            query_params = {
+                k: v[0] for k, v in query_params.items()
+            }
 
-        # 403 Forbidden fix.
-        if "signature" in url or (
-                "s" not in stream and ("&sig=" in url or "&lsig=" in url)
-        ):
-            # For certain videos, YouTube will just provide them pre-signed, in
-            # which case there's no real magic to download them and we can skip
-            # the whole signature descrambling entirely.
-            logger.debug("signature found, skip decipher")
+            # 403 Forbidden fix.
+            if "signature" in url or (
+                    "s" not in stream and ("&sig=" in url or "&lsig=" in url)
+            ):
+                # For certain videos, YouTube will just provide them pre-signed, in
+                # which case there's no real magic to download them and we can skip
+                # the whole signature descrambling entirely.
+                logger.debug("signature found, skip decipher")
 
-        else:
-            signature = cipher.get_sig(ciphered_signature=stream["s"])
-
-            logger.debug(
-                "finished descrambling signature for itag=%s", stream["itag"]
-            )
-
-            query_params['sig'] = signature
-
-        if 'n' in query_params.keys():
-            # For WEB-based clients, YouTube sends an "n" parameter that throttles download speed.
-            # To decipher the value of "n", we must interpret the player's JavaScript.
-
-            initial_n = query_params['n']
-            logger.debug(f'Parameter n is: {initial_n}')
-
-            # Check if any previous stream decrypted the parameter
-            if initial_n not in discovered_n:
-                discovered_n[initial_n] = cipher.get_nsig(initial_n)
             else:
-                logger.debug('Parameter n found skipping decryption')
+                signature = cipher.get_sig(ciphered_signature=stream["s"])
 
-            new_n = discovered_n[initial_n]
-            query_params['n'] = new_n
-            logger.debug(f'Parameter n deciphered: {new_n}')
+                logger.debug(
+                    "finished descrambling signature for itag=%s", stream["itag"]
+                )
 
-        url = f'{parsed_url.scheme}://{parsed_url.netloc}{parsed_url.path}?{urlencode(query_params)}'  # noqa:E501
+                query_params['sig'] = signature
 
-        stream_manifest[i]["url"] = url
+            if 'n' in query_params.keys():
+                # For WEB-based clients, YouTube sends an "n" parameter that throttles download speed.
+                # To decipher the value of "n", we must interpret the player's JavaScript.
 
-    cipher.runner_sig.close()
-    cipher.runner_nsig.close()
+                initial_n = query_params['n']
+                logger.debug(f'Parameter n is: {initial_n}')
+
+                # Check if any previous stream decrypted the parameter
+                if initial_n not in discovered_n:
+                    discovered_n[initial_n] = cipher.get_nsig(initial_n)
+                else:
+                    logger.debug('Parameter n found skipping decryption')
+
+                new_n = discovered_n[initial_n]
+                query_params['n'] = new_n
+                logger.debug(f'Parameter n deciphered: {new_n}')
+
+            url = f'{parsed_url.scheme}://{parsed_url.netloc}{parsed_url.path}?{urlencode(query_params)}'  # noqa:E501
+
+            stream_manifest[i]["url"] = url
+    finally:
+        # Always release the two node subprocesses spawned by Cipher, even if
+        # the loop above raised (LiveStreamError, NodeRunner*Error during a
+        # base.js rotation, network failure, ...). Without this, every failed
+        # call leaks two `node runner.js` children whose stdin pipes stay open
+        # forever, eventually exhausting FDs in long-running hosts.
+        try:
+            cipher.runner_sig.close()
+        finally:
+            cipher.runner_nsig.close()
 
 
 def apply_descrambler(stream_data: Dict) -> Optional[List[Dict]]:


### PR DESCRIPTION
> Resubmit of #643 (originally targeted `main` by mistake — per CONTRIBUTING.md this PR targets `dev` and the commit is now signed off with DCO + `Assisted-by` tag).

## Summary

`Cipher.__init__` spawns two persistent `node` subprocesses via `Popen` (`runner_sig`, `runner_nsig`). `apply_signature` only closes them at the end of the loop, with no `try/finally`. Any exception raised between cipher construction and the final `.close()` calls leaks both children:

```python
cipher = Cipher(js=js, js_url=url_js)         # spawns 2 node procs
discovered_n = dict()
for i, stream in enumerate(stream_manifest):
    ...                                        # may raise — see below
    stream_manifest[i]["url"] = url

cipher.runner_sig.close()                      # skipped on any exception above
cipher.runner_nsig.close()
```

Exception paths that hit this in the wild:

- `LiveStreamError("UNKNOWN")` raised inside the `KeyError` branch
- `NodeRunnerEmptyResponseError` / `NodeRunnerInvalidResponseError` from `_call_with_retry` when YouTube rotates `base.js` and the cached function names go stale
- Any network / decode failure inside `get_sig` / `get_nsig`
- `KeyError` on `stream["s"]` for malformed manifests

When this happens, the two `node ... runner.js` children stay alive with their stdin pipe open, blocked on `readline()`, parented by the caller's Python process forever. `Popen.__del__` does **not** kill them.

## Impact downstream

Reported by a Home Assistant deployment using `ytube_music_player` (which depends on `pytubefix>=10.7.2`). The integration polls in `cloud_polling` mode and retries on failure. After a YouTube `base.js` rotation:

- `apply_signature` started failing inside the loop
- Each failed call leaked **2** node subprocesses
- Over a few hours, hundreds of orphan `node runner.js` children accumulated under the HA python process
- FD exhaustion + asyncio child-watcher overload eventually stalled the HTTP listener (process still alive, port 8123 unresponsive)
- Recovery required restarting Home Assistant

```
PID   USER     TIME  COMMAND
  851 root      3:33 python3 -m homeassistant --config /config
  898 root      0:00 node /usr/local/lib/python3.14/site-packages/pytubefix/sig_nsig/vm/runner.js
  910 root      0:00 node /usr/local/lib/python3.14/site-packages/pytubefix/sig_nsig/vm/runner.js
  ... (many more) ...
```

## Fix

Wrap the loop in `try/finally` and always close both runners on the way out. Nested `try/finally` around the two `.close()` calls so `runner_nsig` is still released if `runner_sig.close()` raises (it shouldn't — `NodeRunner.close` already swallows its own errors — but defence in depth costs nothing).

```python
cipher = Cipher(js=js, js_url=url_js)
try:
    discovered_n = dict()
    for i, stream in enumerate(stream_manifest):
        ...
        stream_manifest[i]["url"] = url
finally:
    try:
        cipher.runner_sig.close()
    finally:
        cipher.runner_nsig.close()
```

The visible diff is large because the loop body is reindented one level under the new `try`. The only behavioural change is the unconditional cleanup. `git blame` users can hide the reindent with `--ignore-rev`.

## Test plan

- [x] Module imports / AST parses
- [x] Manual: confirmed in patched copy that triggering `LiveStreamError` during `apply_signature` no longer leaves `node runner.js` children behind (`ps -ef | grep runner.js` returns 0 after the call instead of 2 per attempt)
- [ ] CI green

## Alternative considered

Making `Cipher` a context manager (`__enter__/__exit__`) would have allowed `with Cipher(...) as cipher:` at the call site and a smaller diff body. Rejected for this PR to keep `Cipher`'s public surface unchanged; happy to do that in a follow-up if maintainers prefer.
