### PR TITLE
docs: add Python versions badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
   <img src="https://img.shields.io/readthedocs/pytubefix">
   <img src="https://img.shields.io/github/v/tag/JuanBindez/pytubefix?include_prereleases">
   <img src="https://img.shields.io/pypi/v/pytubefix">
+  <img src="https://img.shields.io/pypi/pyversions/pytubefix.svg">
 </p>
 
 <h2 align="center">


### PR DESCRIPTION
## Summary

Add the PyPI Python versions badge to the README.

## Changes

- Added the `pyversions` shield from PyPI alongside the existing project badges.
- No code or packaging changes.

## Motivation

This makes supported Python versions immediately visible to users visiting the repository and aligns the README with the compatibility information already published on PyPI.