### PR TITLE
Fix ias undefined nsig

### DIFF
--- a/pytubefix/cipher.py
+++ b/pytubefix/cipher.py
@@ -13,6 +13,7 @@ functions" (2) sends them to be interpreted by nodejs
 import logging
 import re
 import time
+import ast
 from typing import Optional
 
 from pytubefix.exceptions import RegexMatchError, InterpretationError
@@ -78,6 +79,85 @@ def _find_js_array_end(js: str, start: int) -> Optional[int]:
                 return index + 1
 
     return None
+
+
+def _split_js_array_entries(array_body: str) -> list:
+    entries = []
+    token = []
+    depth = 0
+    quote = None
+    escaped = False
+
+    for char in array_body:
+        if quote:
+            token.append(char)
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == quote:
+                quote = None
+            continue
+
+        if char in ("'", '"'):
+            quote = char
+            token.append(char)
+        elif char in "[{(":
+            depth += 1
+            token.append(char)
+        elif char in "]})":
+            depth -= 1
+            token.append(char)
+        elif char == "," and depth == 0:
+            entries.append("".join(token).strip())
+            token = []
+        else:
+            token.append(char)
+
+    entries.append("".join(token).strip())
+    return entries
+
+
+def _decode_js_string_literal(value: str):
+    if len(value) < 2 or value[0] not in ("'", '"') or value[-1] != value[0]:
+        return None
+    try:
+        return ast.literal_eval(value)
+    except Exception:
+        quote = value[0]
+        return (
+            value[1:-1]
+            .replace("\\\\", "\\")
+            .replace("\\" + quote, quote)
+            .replace("\\n", "\n")
+            .replace("\\r", "\r")
+            .replace("\\t", "\t")
+        )
+
+
+def _extract_plain_array_player_js_global_var(js: str):
+    """Extract plain global string tables, e.g. var W=["split", ..., fn]."""
+    for match in re.finditer(
+        r"(?:(?:var|let|const)\s+)?(?P<varname>[A-Za-z0-9_$]+)\s*=\s*\[",
+        js,
+    ):
+        array_start = match.end() - 1
+        array_end = _find_js_array_end(js, array_start)
+        if array_end is None:
+            continue
+
+        array_code = js[array_start:array_end]
+        if "_w8_" not in array_code:
+            continue
+
+        global_obj = []
+        for entry in _split_js_array_entries(array_code[1:-1]):
+            global_obj.append(_decode_js_string_literal(entry))
+
+        if any(isinstance(value, str) and value.endswith("_w8_") for value in global_obj):
+            return match.group("varname"), global_obj
+
+    return None, None
 
 
 def _extract_property_array_player_js_global_var(js: str):
@@ -293,6 +373,8 @@ class Cipher:
             if not varname or not global_arr:
                 varname, global_arr = _extract_property_array_player_js_global_var(self.js)
             if not varname or not global_arr:
+                varname, global_arr = _extract_plain_array_player_js_global_var(self.js)
+            if not varname or not global_arr:
                 return []
 
         w8_idx = None
@@ -318,7 +400,7 @@ class Cipher:
         catch_pattern = re.compile(
             r'catch\s*\([^)]+\)\s*\{\s*[A-Za-z0-9_$]+\s*=\s*'
             + re.escape(varname)
-            + r'\[(?P<xor>[A-Za-z0-9_$]+)\^(?P<const>\d+)\]\s*\+\s*[A-Za-z0-9_$]+\s*;\s*break\s+[A-Za-z_$]+\s*\}'
+            + r'\[(?P<xor>[A-Za-z0-9_$]+)\^\s*(?P<const>\d+)\]\s*\+\s*[A-Za-z0-9_$]+\s*;\s*break\s+[A-Za-z_$]+\s*\}'
         )
         for match in catch_pattern.finditer(body):
             xor_var = match.group("xor")
@@ -548,6 +630,8 @@ class Cipher:
                 varname, global_obj = _extract_split_player_js_global_var(js)
                 if not (varname and global_obj):
                     varname, global_obj = _extract_property_array_player_js_global_var(js)
+                if not (varname and global_obj):
+                    varname, global_obj = _extract_plain_array_player_js_global_var(js)
                 if varname and global_obj:
                     logger.debug(f"TCE global Obj name is: {varname}")
 
@@ -566,7 +650,7 @@ class Cipher:
                         r'catch\s*\([^)]+\)\s*\{\s*'
                         r'[A-Za-z0-9_$]+\s*=\s*'
                         + re.escape(varname) +
-                        r'\[([A-Za-z0-9_$]+)\^(\d+)\]\s*\+\s*([A-Za-z0-9_$]+)\s*;\s*break\s+a\s*\}'
+                        r'\[([A-Za-z0-9_$]+)\^\s*(\d+)\]\s*\+\s*([A-Za-z0-9_$]+)\s*;\s*break\s+a\s*\}'
                     )
                     for cm in xor_catch.finditer(js):
                         xor_var = cm.group(1)


### PR DESCRIPTION
## Summary

This patch hardens nsig discovery for newer YouTube player JavaScript that stores
the `_w8_` marker in a plain global array such as `var W=[...]`.

The existing parser handled interpreted global arrays, split-string TCE tables,
and property-array TCE tables, but regular player `959dabb2` uses a mixed global
array containing string entries alongside function/object references. Evaluating
the whole array is unnecessary and brittle, so this adds a lightweight parser
that extracts only the string slots needed by nsig discovery.

The patch also allows whitespace after XOR operators in catch-block global
lookups, covering minified output that wraps indexes across lines, for example
`W[K^\n7573]`.

## What Changed

- Added plain global array extraction for mixed arrays containing `_w8_`.
- Reused that extraction path in both nsig function discovery and invariant
  derivation.
- Relaxed catch-block XOR lookup regexes to tolerate whitespace after `^`.

## Validation

Validated locally with:

```text
python cipher_player_test.py 959dabb2
python cipher_player_test.py 9d2ef9ef 08bf6746 5cabb421 
```

Results:

- Player `959dabb2` passed for `base`, `ias`, and `ias_tce`.
- Regression sample players `9d2ef9ef`, `08bf6746`, and `5cabb421` passed.

## AI Assistance Disclosure

This contribution was prepared with assistance from Codex 5.5.