### PR TITLE
Override Channel.title to return the channel name

### DIFF
--- a/pytubefix/contrib/channel.py
+++ b/pytubefix/contrib/channel.py
@@ -109,6 +109,18 @@ class Channel(Playlist):
         return self.initial_data['metadata']['channelMetadataRenderer']['title']
 
     @property
+    def title(self) -> str:
+        """Get the title of the YouTube channel.
+
+        The inherited ``Playlist.title`` reads from a ``sidebar`` key that is
+        not present in a channel's initial data, so it is overridden here to
+        return the channel name.
+
+        :rtype: str
+        """
+        return self.channel_name
+
+    @property
     def channel_id(self):
         """Get the ID of the YouTube channel.
 

--- a/tests/contrib/test_channel.py
+++ b/tests/contrib/test_channel.py
@@ -35,6 +35,14 @@ def test_channel_name(request_get, channel_videos_html):
 
 
 @mock.patch('pytubefix.request.get')
+def test_channel_title(request_get, channel_videos_html):
+    request_get.return_value = channel_videos_html
+
+    c = Channel('https://www.youtube.com/c/ProgrammingKnowledge/videos')
+    assert c.title == 'ProgrammingKnowledge'
+
+
+@mock.patch('pytubefix.request.get')
 def test_channel_id(request_get, channel_videos_html):
     request_get.return_value = channel_videos_html
 


### PR DESCRIPTION
Fixes #662.

`Channel` inherits `Playlist.title`, which reads from a `sidebar` key that isn't present in a channel's initial data, so `channel.title` raises `KeyError: 'sidebar'`. This overrides `title` on `Channel` to return `channel_name`, matching the metadata that `channel_name`/`channel_id` already use. Added a test alongside the existing `test_channel_name`.