### PR TITLE
simplify variable usage in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -13,21 +13,16 @@ Fixes:#653
 "
 BRANCH="main"
 
-if [[ -z $PATCH ]]; then
-    PATCH=""
-else
+if [[ -n "${PATCH-}" ]]; then
     PATCH=".$PATCH"
 fi
 
-if [[ $EXTRAVERSION == *"-rc"* ]]; then
-    FULL_VERSION="$VERSION.$MINOR$PATCH$EXTRAVERSION"
-else
+FULL_VERSION="$VERSION.$MINOR$PATCH"
 
-    if [[ -z $EXTRAVERSION ]]; then
-        FULL_VERSION="$VERSION.$MINOR$PATCH"
-    else
-        FULL_VERSION="$VERSION.$MINOR$PATCH.$EXTRAVERSION"
-    fi
+if [[ $EXTRAVERSION == *"-rc"* ]]; then
+    FULL_VERSION+="$EXTRAVERSION"
+elif [[ -n $EXTRAVERSION ]]; then
+    FULL_VERSION+=".$EXTRAVERSION"
 fi
 
 git add .


### PR DESCRIPTION
* Shorten the PATCH variable modification code.
Since the PATCH variable is only modified when it's already set, we only need to check that it is set.

* Simplify setting of FULL_VERSION
This makes it so we set FULL_VERSION to "$VERSION.$MINOR$PATCH".
Then if EXTRAVERSION is set, it will append to FULL_VERSION:
   - "$EXTRAVERSION" if it's an RC
   or
   - ".$EXTRAVERSION" for others.