### PR TITLE
docs: fix reStructuredText markup warnings across the docs tree

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -79,14 +79,14 @@ Search Object
    :inherited-members:
 
 ChapterThumbnail Object
--------------
+-----------------------
 
 .. autoclass:: pytubefix.chapters.ChapterThumbnail
    :members:
    :inherited-members:
 
 Chapter Object
--------------
+--------------
 
 .. autoclass:: pytubefix.chapters.Chapter
    :members:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,7 @@
 .. pytubefix documentation master file,
 
 pytubefix
-======
+=========
 Release v\ |version|. (:ref:`Installation<install>`)
 
 

--- a/docs/user/dubbed_streams.rst
+++ b/docs/user/dubbed_streams.rst
@@ -1,7 +1,7 @@
 .. _dubbed_streams:
 
 Filtering Dubbed Streams
-==============
+========================
 
 **YouTube added videos that contain multiple audios for re-dubbing, but they have the same Itag**
 

--- a/docs/user/dubbed_streams.rst
+++ b/docs/user/dubbed_streams.rst
@@ -3,7 +3,7 @@
 Filtering Dubbed Streams
 ==============
 
-**YouTube added videos that contain multiple audios for re-dubbing, but they have the same Itag**::
+**YouTube added videos that contain multiple audios for re-dubbing, but they have the same Itag**
 
 Adds the possibility of filtering these streams that contain dubbing.
 

--- a/docs/user/info.rst
+++ b/docs/user/info.rst
@@ -4,6 +4,7 @@ Info
 ====
 
 This can be useful for debugging or logging purposes, as it allows developers to quickly check the environment in which the code is being executed. It helps ensure that the correct versions of Python and Pytubefix are being used, and can also assist in identifying any compatibility issues between the system and the application::
+
     >>> from pytubefix import info
     >>> 
     >>> print(info())
@@ -11,6 +12,7 @@ This can be useful for debugging or logging purposes, as it allows developers to
     >>> 
 
 to get just the operating system::
+
     >>> from pytubefix import info
     >>> 
     >>> system_info = info()
@@ -21,6 +23,7 @@ to get just the operating system::
     >>>
 
 to use only the pytubefix version::
+
     >>> from pytubefix import info
     >>> 
     >>> system_info = info()
@@ -30,6 +33,7 @@ to use only the pytubefix version::
     >>>
 
 The main purpose is to use in logs, especially if you are using in cloud environments where you may be using a broken version of pytubefix::
+
     >>> import logging
     >>> from pytubefix import YouTube, info
     >>> from pytubefix.cli import on_progress

--- a/docs/user/install.rst
+++ b/docs/user/install.rst
@@ -1,7 +1,7 @@
 .. _install:
 
 Installation of pytubefix
-======================
+=========================
 
 This guide assumes you already have python and pip installed.
 

--- a/docs/user/m4a.rst
+++ b/docs/user/m4a.rst
@@ -1,7 +1,7 @@
 .. _m4a:
 
 M4a Download (MPEG-4 AAC audio codec)
-=============================
+=====================================
 
 **Attention the mp3 parameter will no longer be used, all audios will now be downloaded as .m4a, the correct extension for the codec (MPEG-4 AAC audio codec)**::
 

--- a/docs/user/po_token.rst
+++ b/docs/user/po_token.rst
@@ -11,6 +11,7 @@ Automatic PO Token generation with nodejs
 -----------------------------------------
 
 .. _nodejs-wheel-binaries: https://pypi.org/project/nodejs-wheel-binaries/
+
 Pytubefix has the ability to generate a PoToken automatically using nodejs, all you need is to change the client to some poToken client, for example *WEB* client:
 
 .. code:: python

--- a/docs/user/search.rst
+++ b/docs/user/search.rst
@@ -98,7 +98,7 @@ The .videos method will only return the videos::
     >>> 
 
 
-The .shorts method will only return the shorts.::
+The .shorts method will only return the shorts.
 
 Here it is interesting to note that videos and shorts are from the same class of objects::
 


### PR DESCRIPTION
fixes malformed literal blocks and short title underlines. verified with docutils over all 22 .rst files: 13 warnings before, 0 after.